### PR TITLE
Bannery do článku z CMS místo ručně lepeného HTML

### DIFF
--- a/_backup/webflow/custom-code/_MANIFEST.md
+++ b/_backup/webflow/custom-code/_MANIFEST.md
@@ -1,6 +1,11 @@
 # Záloha custom kódu — Webflow ELDR
 Site ID: 635940ec249b210e8902edd4 · Workspace: 63593aa9923e4a3417813ca5
-Pořízeno: 2026-08-15 · Stav webu: publikováno 2026-06-29
+Pořízeno: 2026-08-27 · Stav webu: publikováno 2026-08-17
+
+⚠️ Tahle záloha se ROZEŠLA s realitou (byla z 15. 8., live mezitím přešel
+na sloučený bundle). Kdo se na ni spolehne, udělá špatné rozhodnutí —
+před prací se site head/footer si vždycky vytáhni aktuální stav přes
+`data_scripts_tool > get_site_freeform_code` a tenhle soubor přepiš.
 
 | Soubor | Umístění ve Webflow |
 |---|---|

--- a/_backup/webflow/custom-code/site-footer.html
+++ b/_backup/webflow/custom-code/site-footer.html
@@ -2,102 +2,22 @@
 <script defer src="https://cdn.jsdelivr.net/npm/@finsweet/cookie-consent@1/fs-cc.js" fs-cc-mode="opt-in"></script>
 <!-- End Finsweet Cookie Consent -->
 
-<!-- jQuery -->
-<script defer src="https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>
-<!-- End jQuery -->
-
-<!-- Swiper.js Stylesheets
-<link rel="stylesheet" href="https://unpkg.com/swiper/swiper-bundle.min.css" />
-End Swiper -->
-
 <!-- Swiper.js Library -->
 <script defer src="https://unpkg.com/swiper@8/swiper-bundle.min.js"></script>
 <!-- End Swiper JS Library -->
 
 <!-- Webkit Studio Code -->
-<script defer src="https://cdn.jsdelivr.net/gh/lukas-webkit-studio/eldr@v1.2.27/index.min.js"></script>
-<script defer src="https://cdn.jsdelivr.net/gh/lukas-webkit-studio/eldr@v1.2.27/sliders.min.js"></script>
-<script defer src="https://cdn.jsdelivr.net/gh/lukas-webkit-studio/eldr@v1.2.28/current-year.min.js"></script>
+<script defer src="https://cdn.jsdelivr.net/gh/lukas-webkit-studio/eldr@f0200cd/dist/eldr.min.js"></script>
 <!-- End Webkit Studio Code -->
 
 <!-- Lead Script -->
 <script>
-!(function (l, s) {
-l.type = "text/javascript";
-l.async = true;
-l.src = "https://" + "ct.l" + "eady.com/R6vz1S8NAqk4NrQ8/L" + ".js";
-s = s[0];
-s.parentNode.insertBefore(l, s);
-})(document.createElement("script"), document.getElementsByTagName("script"));
+  !(function (l, s) {
+    l.type = 'text/javascript';
+    l.async = true;
+    l.src = 'https://' + 'ct.l' + 'eady.com/R6vz1S8NAqk4NrQ8/L' + '.js';
+    s = s[0];
+    s.parentNode.insertBefore(l, s);
+  })(document.createElement('script'), document.getElementsByTagName('script'));
 </script>
 <!-- End Lead Script -->
-
-<!-- Google Tag Manager Scripts -->
-<script>
-document.addEventListener("DOMContentLoaded", function(){
-
-    // Form
-    const contactForms = document.querySelectorAll(".Form__Type1");
-    contactForms.forEach(form => {
-        form.addEventListener("submit", function() {
-            dataLayer.push({
-                'event' : 'contact_form_submit'
-            });
-        });
-    });
-  
-  	// Navbar
-  	const navButtons = document.querySelectorAll(".navbar__link");
-  	navButtons.forEach(button => {
-        button.addEventListener("click", function() {
-            const buttonText = this.innerText
-            dataLayer.push({
-                "event" : "menu_click",
-                "button_text" : buttonText
-            });
-        });
-    });
-  	
-	// Buttons
-  	const redButtons = document.querySelectorAll(".button--primary");
-  	redButtons.forEach(button => {
-        button.addEventListener("click", function() {
-            const buttonText = this.innerText;
-          	const closestSection = this.closest('section');
-        	const sectionName = closestSection && closestSection.id ? closestSection.id : 'Sekce bez názvu';
-            dataLayer.push({
-            	"event" : "button_click",
-            	"button_text" : buttonText,
-            	"section" : sectionName
-            });
-        });
-    }); 
-  	
-  	// Produkty na domovské stránce
-  	const TopProducts = document.querySelectorAll(".sectiontopproducts__item");
-  	TopProducts.forEach(button => {
-        button.addEventListener("click", function() {
-            const buttonText = this.querySelector('h2');
-            dataLayer.push({
-            'event' : 'button_click',
-            'button_text' : buttonText,
-            'section' : 'Home page'
-            });
-        });
-    }); 
-  	
-  	// Menu na stránce Naše výrobky
-  	const MenuProducts = document.querySelectorAll(".sectionproducts__item");
-  	MenuProducts.forEach(button => {
-        button.addEventListener("click", function() {
-            const buttonText = this.querySelector('h5');
-            dataLayer.push({
-            'event' : 'button_click',
-            'button_text' : buttonText,
-            'section' : 'Naše výrobky'
-            });
-        });
-    }); 
-});
-</script>
-<!-- End Google Tag Manager Scripts -->

--- a/_backup/webflow/custom-code/site-footer.html
+++ b/_backup/webflow/custom-code/site-footer.html
@@ -7,7 +7,7 @@
 <!-- End Swiper JS Library -->
 
 <!-- Webkit Studio Code -->
-<script defer src="https://cdn.jsdelivr.net/gh/lukas-webkit-studio/eldr@f0200cd/dist/eldr.min.js"></script>
+<script defer src="https://cdn.jsdelivr.net/gh/lukas-webkit-studio/eldr@bc1fadf/dist/eldr.min.js"></script>
 <!-- End Webkit Studio Code -->
 
 <!-- Lead Script -->

--- a/_backup/webflow/custom-code/site-head.html
+++ b/_backup/webflow/custom-code/site-head.html
@@ -29,5 +29,5 @@
 <!-- End [Attributes by Finsweet] -->
 
 <!-- Webkit Studio Code -->
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/lukas-webkit-studio/eldr@f0200cd/dist/eldr.min.css" />
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/lukas-webkit-studio/eldr@bc1fadf/dist/eldr.min.css" />
 <!-- End Webkit Studio Code -->

--- a/_backup/webflow/custom-code/site-head.html
+++ b/_backup/webflow/custom-code/site-head.html
@@ -1,10 +1,19 @@
 <!-- Theme Color -->
-<meta name="theme-color" content="#fcfcfc">
+<meta name="theme-color" content="#fcfcfc" />
 <!-- End Theme Color -->
 
-<!-- Google Tag Manager --> 
+<!-- Google Tag Manager -->
 <script>
-(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0], j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src= 'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f); })(window,document,'script','dataLayer','GTM-W6PR2VX');
+  (function (w, d, s, l, i) {
+    w[l] = w[l] || [];
+    w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' });
+    var f = d.getElementsByTagName(s)[0],
+      j = d.createElement(s),
+      dl = l != 'dataLayer' ? '&l=' + l : '';
+    j.async = true;
+    j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
+    f.parentNode.insertBefore(j, f);
+  })(window, document, 'script', 'dataLayer', 'GTM-W6PR2VX');
 </script>
 <!-- End Google Tag Manager -->
 
@@ -16,12 +25,9 @@
 <!-- CMS Filter -->
 <script async src="https://cdn.jsdelivr.net/npm/@finsweet/attributes-cmsfilter@1/cmsfilter.js"></script>
 <!-- List Nest -->
-<script async type="module"
-src="https://cdn.jsdelivr.net/npm/@finsweet/attributes@2/attributes.js"
-fs-list
-></script>
+<script async type="module" src="https://cdn.jsdelivr.net/npm/@finsweet/attributes@2/attributes.js" fs-list></script>
 <!-- End [Attributes by Finsweet] -->
 
 <!-- Webkit Studio Code -->
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/lukas-webkit-studio/eldr@57d0495/dist/eldr.min.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/lukas-webkit-studio/eldr@f0200cd/dist/eldr.min.css" />
 <!-- End Webkit Studio Code -->

--- a/dist/eldr.js
+++ b/dist/eldr.js
@@ -129,16 +129,17 @@ function locale() {
    — přepisuje třídy, ručně lepí URL obrázků a kopíruje `w-node-…` id. Každý
    překlep je rozbitý banner a obrázky jdou bez srcset v plné velikosti.
 
-   Nově je banner záznam v CMS kolekci Bannery. Šablona článku ho vykreslí do
-   skrytého zdroje `[data-banner-source]` ve správné Webflow struktuře (živé
-   třídy, responzivní srcset, alt texty). V textu článku zůstane jen zástupný
-   odstavec `[banner:nazev]`, který tenhle modul vymění za hotový banner.
+   Nově je banner záznam v CMS kolekci Bannery. Šablona článku vykreslí CELOU
+   kolekci do skrytého zdroje `[data-banner-source]` ve správné Webflow
+   struktuře (živé třídy, responzivní srcset, alt texty) — funguje tedy jako
+   knihovna. V kolekci Inspirace se nemění nic; klient jen napíše do textu
+   `[banner:nazev]` a modul to vymění za hotový banner.
 
    Kontrakt se šablonou (podrobně v docs/bannery-cms.md):
-     [data-banner-source]    skrytý wrapper s Collection Listem kolekce Bannery
-     [data-banner="slug"]    položka seznamu, uvnitř hotová struktura banneru
-     [data-banner-fallback]  volitelné místo pro banner, na který se v textu
-                             zapomnělo (bez něj se takový banner nevykreslí)
+     [data-banner-source]   skrytý wrapper s Collection Listem kolekce Bannery
+     [data-banner="slug"]   položka seznamu, uvnitř hotová struktura banneru
+     [data-banner-name]     Název banneru — druhý klíč, aby klient nemusel
+                            hlídat slug a mohl napsat i „Pylony – velký"
 
    POŘADÍ V BUNDLU — proto 05, hned za jádrem:
    - před 10-vars → tokeny {#YOE#} se doplní i do vloženého banneru
@@ -148,24 +149,33 @@ function locale() {
 
 (function () {
   var SOURCE = '[data-banner-source]';
-  var FALLBACK = '[data-banner-fallback]';
   var ITEM = '[data-banner]';
   var RICH = '.w-richtext';
+  var BLOCKS = 'p, li, blockquote, h1, h2, h3, h4, h5, h6';
 
-  /* `[banner:nazev-banneru]`, nebo holé `[banner]` = vezmi další v pořadí,
-     jak jsou vybrané v CMS. Mezery kolem dvojtečky se odpouštějí, velikost
-     písmen taky — klient píše do textového pole, ne do kódu. */
-  var TOKEN = /^\[banner(?:\s*:\s*([^\]]+))?\]$/i;
+  /* `[banner:nazev]`. Mezery kolem dvojtečky se odpouštějí, diakritika
+     a velikost písmen taky — klient píše do textového pole, ne do kódu.
+     Název je nepovinný jen proto, aby se holé `[banner]` dalo z textu uklidit
+     a nezůstalo na očích čtenáři. */
+  var TOKEN = /\[banner\s*(?::\s*([^\]\r\n]+))?\]/gi;
 
   var source = $1(SOURCE);
   if (!source) return;
 
-  /* Skrytí patří do Designeru (kdyby skript nedojel, nesmí se zdroj ukázat).
-     Tady je jen pojistka proti tomu, aby ho někdo ve Webflow omylem odkryl. */
+  /* Skrytí patří do Designeru (kdyby skript nedojel, nesmí se knihovna
+     ukázat). Tady je jen pojistka, aby ji někdo ve Webflow omylem neodkryl. */
   source.style.display = 'none';
 
   function warn(message) {
     if (window.console && console.warn) console.warn('[ELDR bannery] ' + message);
+  }
+
+  /* „Pylony – velký", „pylony-velky" i „Pylony velky" musí vést na stejný
+     banner. Bez toho by klient musel opisovat slug znak po znaku. */
+  function key(value) {
+    var text = (value || '').trim().toLowerCase();
+    if (text.normalize) text = text.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+    return text.replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
   }
 
   /* Webflow nechává v HTML i prvky schované podmíněnou viditelností
@@ -193,71 +203,79 @@ function locale() {
     return frag.childNodes.length ? frag : null;
   }
 
-  var items = $$(ITEM, source).filter(function (item) { return !isDropped(item); });
-  var used = [];
+  var library = {};
 
-  function slugOf(item) {
-    return (item.getAttribute('data-banner') || '').trim().toLowerCase();
-  }
-
-  function take(name) {
-    var i;
-    if (name) {
-      for (i = 0; i < items.length; i++) {
-        if (slugOf(items[i]) === name) return items[i];
-      }
-      return null;
-    }
-    for (i = 0; i < items.length; i++) {
-      if (used.indexOf(items[i]) === -1) return items[i];
-    }
-    return null;
-  }
-
-  /* Zástupný odstavec musí být v odstavci sám. Banner je <section>, uvnitř
-     <p> by byl neplatný HTML a prohlížeč by ho z odstavce stejně vystrčil. */
-  function placeholders() {
-    var found = [];
-    $$(RICH).forEach(function (rich) {
-      if (source.contains(rich)) return;
-      $$('p', rich).forEach(function (p) {
-        var match = TOKEN.exec((p.textContent || '').trim());
-        if (match) found.push({ el: p, name: (match[1] || '').trim().toLowerCase() });
-      });
+  $$(ITEM, source).forEach(function (item) {
+    if (isDropped(item)) return;
+    [item.getAttribute('data-banner'), item.getAttribute('data-banner-name')].forEach(function (name) {
+      var k = key(name);
+      if (k && !library[k]) library[k] = item;
     });
-    return found;
+  });
+
+  /* Token se z textu odstraňuje po textových uzlech, ne přes innerHTML —
+     odkazy a tučný text uvnitř odstavce musí zůstat nedotčené. */
+  function stripTokens(block) {
+    var walker = document.createTreeWalker(block, NodeFilter.SHOW_TEXT, null);
+    var nodes = [];
+    var node;
+    while ((node = walker.nextNode())) nodes.push(node);
+    nodes.forEach(function (text) {
+      if (text.nodeValue.indexOf('[') === -1) return;
+      TOKEN.lastIndex = 0;
+      text.nodeValue = text.nodeValue.replace(TOKEN, '');
+    });
+  }
+
+  function process(block) {
+    var text = block.textContent || '';
+    if (text.indexOf('[') === -1) return;
+
+    var frags = [];
+    var match;
+
+    TOKEN.lastIndex = 0;
+    while ((match = TOKEN.exec(text))) {
+      var name = key(match[1]);
+
+      if (!name) {
+        warn('v textu je [banner] bez názvu — nevím, který vložit');
+        continue;
+      }
+
+      var item = library[name];
+      if (!item) {
+        warn('banner „' + name + '" v kolekci Bannery neexistuje nebo není publikovaný');
+        continue;
+      }
+
+      var banner = build(item);
+      if (banner) frags.push(banner);
+    }
+
+    /* Token mizí z textu vždycky. I když se banner nenajde, čtenář nesmí
+       v článku vidět holé `[banner:…]`. */
+    stripTokens(block);
+
+    /* Banner smí být sourozenec odstavce, ne jeho obsah — <section> uvnitř
+       <p> je neplatný HTML a prohlížeč by ho z odstavce stejně vystrčil. */
+    var anchor = block;
+    frags.forEach(function (frag) {
+      var last = frag.lastChild;
+      anchor.parentNode.insertBefore(frag, anchor.nextSibling);
+      anchor = last;
+    });
+
+    /* Odstavec, ve kterém byl jen token, po úklidu zůstal prázdný. */
+    if (!block.textContent.trim() && !block.children.length && block.parentNode) {
+      block.parentNode.removeChild(block);
+    }
   }
 
   onReady(function () {
-    placeholders().forEach(function (slot) {
-      var item = take(slot.name);
-      var banner = item && build(item);
-
-      if (banner) {
-        slot.el.parentNode.insertBefore(banner, slot.el);
-        if (used.indexOf(item) === -1) used.push(item);
-      } else if (slot.name) {
-        warn('banner „' + slot.name + '" v článku není vybraný nebo v CMS neexistuje');
-      } else {
-        warn('v textu je [banner] navíc — v CMS už žádný další nezbyl');
-      }
-
-      /* Zástupný odstavec mizí vždycky. I když se banner nenajde, čtenář
-         nesmí v textu vidět holé `[banner:…]`. */
-      slot.el.parentNode.removeChild(slot.el);
-    });
-
-    /* Banner vybraný v CMS, na který se v textu zapomnělo. Bez záchytného
-       místa by tiše zmizel a nikdo by si toho nevšiml. */
-    var fallback = $1(FALLBACK);
-    if (!fallback) return;
-
-    items.forEach(function (item) {
-      if (used.indexOf(item) !== -1) return;
-      var banner = build(item);
-      if (!banner) return;
-      warn('banner „' + slugOf(item) + '" nemá v textu [banner:…], vykreslil se na náhradní místo');
-      fallback.appendChild(banner);
+    $$(RICH).forEach(function (rich) {
+      if (source.contains(rich)) return;
+      $$(BLOCKS, rich).forEach(process);
     });
   });
 })();

--- a/dist/eldr.js
+++ b/dist/eldr.js
@@ -1123,7 +1123,11 @@ function locale() {
    ========================================================================== */
 
 (function () {
-  var scope = $1('[data-ai-share]');
+  /* Hák je ve Webflow zapsaný jako DOM id, ne jako custom atribut
+     (`<div id="data-ai-share">`). Selektor `[data-ai-share]` na id nesedí,
+     takže se modul tiše vypnul a tlačítka zůstala na href="#" — klik pak
+     nedělal nic. Bereme obojí, ať na tom volba pole ve Webflow nestojí. */
+  var scope = $1('[data-ai-share], #data-ai-share');
   if (!scope) return;
 
   var pageUrl = location.href.split('#')[0];

--- a/dist/eldr.js
+++ b/dist/eldr.js
@@ -136,10 +136,18 @@ function locale() {
    `[banner:nazev]` a modul to vymění za hotový banner.
 
    Kontrakt se šablonou (podrobně v docs/bannery-cms.md):
-     [data-banner-source]   skrytý wrapper s Collection Listem kolekce Bannery
-     [data-banner="slug"]   položka seznamu, uvnitř hotová struktura banneru
-     [data-banner-name]     Název banneru — druhý klíč, aby klient nemusel
-                            hlídat slug a mohl napsat i „Pylony – velký"
+     [data-banner-source]     skrytý wrapper s Collection Listem kolekce Bannery
+     .banner-item             položka knihovny; její id = slug banneru
+     .banner-name             skrytý text s Názvem — druhý klíč, aby klient
+                              nemusel hlídat slug a mohl napsat „Pylony – velký"
+     [data-banner-variant]    velký / malý provedení uvnitř položky
+
+   Proč id a skrytý text místo data atributů: Webflow Data API neumí na
+   položce Collection Listu navázat custom atribut na CMS pole. Navázat jde
+   DOM id a text, takže klíče jedou přes ně. Stejný důvod má i výběr varianty
+   — podmíněná viditelnost přes API nejde nastavit na Option pole, takže
+   šablona vykreslí obě provedení, Webflow to nepoužité označí
+   `w-condition-invisible` (podle přepínače Velký banner) a vybere se tady.
 
    POŘADÍ V BUNDLU — proto 05, hned za jádrem:
    - před 10-vars → tokeny {#YOE#} se doplní i do vloženého banneru
@@ -149,7 +157,9 @@ function locale() {
 
 (function () {
   var SOURCE = '[data-banner-source]';
-  var ITEM = '[data-banner]';
+  var ITEM = '.banner-item';
+  var NAME = '.banner-name';
+  var VARIANT = '[data-banner-variant]';
   var RICH = '.w-richtext';
   var BLOCKS = 'p, li, blockquote, h1, h2, h3, h4, h5, h6';
 
@@ -186,28 +196,30 @@ function locale() {
       el.classList.contains('w-dyn-bind-empty');
   }
 
-  /* Klonuje se OBSAH položky, ne položka samotná — ta nese `w-dyn-item`
-     a `role="listitem"`, co v článku nemá co dělat. */
+  /* Klonuje se jen vybrané provedení, ne celá položka — ta nese obal
+     Collection Listu a skrytý nosič názvu, co v článku nemá co dělat.
+     V DOM je velký první, takže když ho přepínač nechá projít, vyhraje. */
   function build(item) {
-    var frag = document.createDocumentFragment();
+    var chosen = $$(VARIANT, item).filter(function (el) { return !isDropped(el); })[0];
+    if (!chosen) return null;
 
-    Array.prototype.slice.call(item.children).forEach(function (child) {
-      if (isDropped(child)) return;
-      var clone = child.cloneNode(true);
-      $$('.w-condition-invisible, .w-dyn-bind-empty', clone).forEach(function (el) {
-        if (el.parentNode) el.parentNode.removeChild(el);
-      });
-      frag.appendChild(clone);
+    var clone = chosen.cloneNode(true);
+    clone.removeAttribute('data-banner-variant');
+    $$('.w-condition-invisible, .w-dyn-bind-empty', clone).forEach(function (el) {
+      if (el.parentNode) el.parentNode.removeChild(el);
     });
 
-    return frag.childNodes.length ? frag : null;
+    var frag = document.createDocumentFragment();
+    frag.appendChild(clone);
+    return frag;
   }
 
   var library = {};
 
   $$(ITEM, source).forEach(function (item) {
     if (isDropped(item)) return;
-    [item.getAttribute('data-banner'), item.getAttribute('data-banner-name')].forEach(function (name) {
+    var named = $1(NAME, item);
+    [item.id, named && named.textContent].forEach(function (name) {
       var k = key(name);
       if (k && !library[k]) library[k] = item;
     });

--- a/dist/eldr.js
+++ b/dist/eldr.js
@@ -1,7 +1,7 @@
 /*!
  * ELDR — sloučený skript webu eldr.cz
  * Sestaveno z src/modules/ — needituj tento soubor, uprav zdroj a spusť `node build.js`.
- * Moduly: 00-core.js, 10-vars.js, 20-locale.js, 30-scroll-lock.js, 31-gallery.js, 32-gallery-height.js, 40-counter.js, 41-long-text.js, 42-tabs.js, 43-video-modal.js, 44-history-swipe.js, 50-form-locale.js, 60-ai-share.js, 90-gtm-events.js
+ * Moduly: 00-core.js, 05-banners.js, 10-vars.js, 20-locale.js, 30-scroll-lock.js, 31-gallery.js, 32-gallery-height.js, 40-counter.js, 41-long-text.js, 42-tabs.js, 43-video-modal.js, 44-history-swipe.js, 50-form-locale.js, 60-ai-share.js, 90-gtm-events.js
  */
 (function () {
 'use strict';
@@ -119,6 +119,148 @@ function locale() {
   var seg = window.location.pathname.split('/')[1];
   return LOCALES.indexOf(seg) !== -1 ? seg : 'cs';
 }
+
+/* ==========================================================================
+   Bannery z CMS — vložení do článku bez ručního HTML
+   --------------------------------------------------------------------------
+   Dnešní stav: banner se do článku vlepuje jako escapovaný HTML do rich textu
+   (`&lt;section class=&quot;banner-cta-big&quot;…`) a Finsweet
+   `attributes-richtext` ho na klientovi rozbalí. Klient tím pádem edituje kód
+   — přepisuje třídy, ručně lepí URL obrázků a kopíruje `w-node-…` id. Každý
+   překlep je rozbitý banner a obrázky jdou bez srcset v plné velikosti.
+
+   Nově je banner záznam v CMS kolekci Bannery. Šablona článku ho vykreslí do
+   skrytého zdroje `[data-banner-source]` ve správné Webflow struktuře (živé
+   třídy, responzivní srcset, alt texty). V textu článku zůstane jen zástupný
+   odstavec `[banner:nazev]`, který tenhle modul vymění za hotový banner.
+
+   Kontrakt se šablonou (podrobně v docs/bannery-cms.md):
+     [data-banner-source]    skrytý wrapper s Collection Listem kolekce Bannery
+     [data-banner="slug"]    položka seznamu, uvnitř hotová struktura banneru
+     [data-banner-fallback]  volitelné místo pro banner, na který se v textu
+                             zapomnělo (bez něj se takový banner nevykreslí)
+
+   POŘADÍ V BUNDLU — proto 05, hned za jádrem:
+   - před 10-vars → tokeny {#YOE#} se doplní i do vloženého banneru
+   - před 90-gtm  → na tlačítko banneru stihne sednout měření button_click
+     (dnes na něm neměří nic: Finsweet ho vykreslí až po DOMContentLoaded)
+   ========================================================================== */
+
+(function () {
+  var SOURCE = '[data-banner-source]';
+  var FALLBACK = '[data-banner-fallback]';
+  var ITEM = '[data-banner]';
+  var RICH = '.w-richtext';
+
+  /* `[banner:nazev-banneru]`, nebo holé `[banner]` = vezmi další v pořadí,
+     jak jsou vybrané v CMS. Mezery kolem dvojtečky se odpouštějí, velikost
+     písmen taky — klient píše do textového pole, ne do kódu. */
+  var TOKEN = /^\[banner(?:\s*:\s*([^\]]+))?\]$/i;
+
+  var source = $1(SOURCE);
+  if (!source) return;
+
+  /* Skrytí patří do Designeru (kdyby skript nedojel, nesmí se zdroj ukázat).
+     Tady je jen pojistka proti tomu, aby ho někdo ve Webflow omylem odkryl. */
+  source.style.display = 'none';
+
+  function warn(message) {
+    if (window.console && console.warn) console.warn('[ELDR bannery] ' + message);
+  }
+
+  /* Webflow nechává v HTML i prvky schované podmíněnou viditelností
+     (`w-condition-invisible`) a prvky s prázdným CMS polem
+     (`w-dyn-bind-empty`) — typicky druhý obrázek, který se vyplňovat nemusí. */
+  function isDropped(el) {
+    return el.classList.contains('w-condition-invisible') ||
+      el.classList.contains('w-dyn-bind-empty');
+  }
+
+  /* Klonuje se OBSAH položky, ne položka samotná — ta nese `w-dyn-item`
+     a `role="listitem"`, co v článku nemá co dělat. */
+  function build(item) {
+    var frag = document.createDocumentFragment();
+
+    Array.prototype.slice.call(item.children).forEach(function (child) {
+      if (isDropped(child)) return;
+      var clone = child.cloneNode(true);
+      $$('.w-condition-invisible, .w-dyn-bind-empty', clone).forEach(function (el) {
+        if (el.parentNode) el.parentNode.removeChild(el);
+      });
+      frag.appendChild(clone);
+    });
+
+    return frag.childNodes.length ? frag : null;
+  }
+
+  var items = $$(ITEM, source).filter(function (item) { return !isDropped(item); });
+  var used = [];
+
+  function slugOf(item) {
+    return (item.getAttribute('data-banner') || '').trim().toLowerCase();
+  }
+
+  function take(name) {
+    var i;
+    if (name) {
+      for (i = 0; i < items.length; i++) {
+        if (slugOf(items[i]) === name) return items[i];
+      }
+      return null;
+    }
+    for (i = 0; i < items.length; i++) {
+      if (used.indexOf(items[i]) === -1) return items[i];
+    }
+    return null;
+  }
+
+  /* Zástupný odstavec musí být v odstavci sám. Banner je <section>, uvnitř
+     <p> by byl neplatný HTML a prohlížeč by ho z odstavce stejně vystrčil. */
+  function placeholders() {
+    var found = [];
+    $$(RICH).forEach(function (rich) {
+      if (source.contains(rich)) return;
+      $$('p', rich).forEach(function (p) {
+        var match = TOKEN.exec((p.textContent || '').trim());
+        if (match) found.push({ el: p, name: (match[1] || '').trim().toLowerCase() });
+      });
+    });
+    return found;
+  }
+
+  onReady(function () {
+    placeholders().forEach(function (slot) {
+      var item = take(slot.name);
+      var banner = item && build(item);
+
+      if (banner) {
+        slot.el.parentNode.insertBefore(banner, slot.el);
+        if (used.indexOf(item) === -1) used.push(item);
+      } else if (slot.name) {
+        warn('banner „' + slot.name + '" v článku není vybraný nebo v CMS neexistuje');
+      } else {
+        warn('v textu je [banner] navíc — v CMS už žádný další nezbyl');
+      }
+
+      /* Zástupný odstavec mizí vždycky. I když se banner nenajde, čtenář
+         nesmí v textu vidět holé `[banner:…]`. */
+      slot.el.parentNode.removeChild(slot.el);
+    });
+
+    /* Banner vybraný v CMS, na který se v textu zapomnělo. Bez záchytného
+       místa by tiše zmizel a nikdo by si toho nevšiml. */
+    var fallback = $1(FALLBACK);
+    if (!fallback) return;
+
+    items.forEach(function (item) {
+      if (used.indexOf(item) !== -1) return;
+      var banner = build(item);
+      if (!banner) return;
+      warn('banner „' + slugOf(item) + '" nemá v textu [banner:…], vykreslil se na náhradní místo');
+      fallback.appendChild(banner);
+    });
+  });
+})();
 
 /* ==========================================================================
    Globální proměnné a tokeny

--- a/docs/bannery-cms.md
+++ b/docs/bannery-cms.md
@@ -37,11 +37,19 @@ Co to obnáší:
 stávajících článků. Klient nikdy nevidí kód a struktura banneru žije
 v Designeru, takže se dá kdykoli přestylovat na jednom místě.
 
-## Stav
+## Stav — hotovo, čeká na publish
 
-**Kolekce Bannery je založená a naplněná** (`6a90303011d6493faa8a946a`) — 15 záznamů
-vytažených ze živého webu, obrázky napojené na stávající assety. Zbývá postavit
-strukturu v Designeru a přepsat články.
+Ve Webflow je všechno postavené. **Zbývá jediné: publikovat web.**
+
+- kolekce **Bannery** (`6a90303011d6493faa8a946a`) — 15 záznamů vytažených
+  ze živého webu, obrázky napojené na stávající assety
+- skrytý zdroj na šabloně `/inspirace/` (`66b0d0179491e21cce3f8302`) —
+  Collection List nad celou kolekcí, obě provedení banneru navázaná na CMS
+- všech **8 článků přepsáno** na tokeny, ověřeno bajt po bajtu proti
+  původnímu textu; žádný starý embed nezůstal
+- site head i footer bumpnuté na commit `f0200cd`
+- šablona `Bannery Template` přepnutá na draft, ať nevznikne veřejná
+  stránka `/bannery/…` s tenkým obsahem
 
 ## Datový model — kolekce Bannery
 
@@ -75,14 +83,26 @@ jen se nepoužité pole přestane vykreslovat.
    pro jistotu nastaví i sám.)
 2. **Collection List** uvnitř, zdroj **Bannery** (celá kolekce, bez filtru).
    Limit nech na 100.
-3. Na **Collection Item** dej custom atributy:
-   - `data-banner` → vazba na pole *Slug*
-   - `data-banner-name` → vazba na pole *Name*
-4. Dovnitř položky vlož **dvě sekce** — `banner-cta-big` a `banner-cta-small`
-   ve stejné struktuře, jakou má dnešní embed, s poli navázanými na CMS.
-   Každé nastav **Conditional visibility**: `Typ = Velký`, resp. `Typ = Malý`.
-5. Obrázkům nech **Loading: lazy**. Ve skrytém zdroji se pak nestahují;
+3. Uvnitř položky **Div `.banner-item`**, jeho **DOM id navázané na Slug**.
+   Tohle je klíč, na který míří `[banner:…]`.
+4. V něm **Div `.banner-name`** (display none) s **textem navázaným na Name** —
+   druhý klíč, aby klient mohl psát i „Pylony – velký".
+5. Vedle něj **dvě sekce** — `banner-cta-big` a `banner-cta-small` ve stejné
+   struktuře, jakou má dnešní embed, s poli navázanými na CMS. Každá má
+   statický atribut `data-banner-variant` (`velky` / `maly`).
+6. Velké sekci nastav **viditelnost navázanou na přepínač Velký banner**.
+   Malá zůstává vždy viditelná — modul si vybere tu, která projde.
+7. Obrázkům nech **Loading: lazy**. Ve skrytém zdroji se pak nestahují;
    stáhnou se až po vložení do článku.
+
+### Proč zrovna takhle
+
+Webflow Data API **neumí** dvě věci, které by se v Designeru naklikaly:
+navázat custom atribut na položce Collection Listu a nastavit podmíněnou
+viditelnost podle Option pole. Odtud DOM id místo `data-banner`, skrytý text
+místo `data-banner-name` a Switch místo Option. Kdo to bude překopávat ručně
+v Designeru, může použít i původní varianty — modul je na klíče nenáročný,
+jen musí sedět `.banner-item`, `.banner-name` a `data-banner-variant`.
 
 ### Pojmenování tříd (client-first)
 
@@ -106,8 +126,9 @@ v menu u názvu třídy dej **Duplicate class** (vznikne kopie se všemi
 vlastnostmi), přejmenuj ji na client-first název a starou třídu z prvku
 odeber. Nepřepisuj styly ručně, rozjede se to.
 
-**Staré třídy zatím nemazat** — drží vzhled bannerů ve starých článcích,
-dokud nejsou přepsané. Až budou, jdou pryč (jsou i v `_backup/FINDINGS.md`).
+**Přejmenování až po publikaci.** Struktura je zatím postavená na starých
+třídách, aby vzhled seděl 1:1. Přejmenovat je jde teprve až bude nový systém
+odpublikovaný a ověřený — do té doby drží vzhled i staré publikované články.
 
 ### Na co si dát pozor
 
@@ -202,9 +223,18 @@ konečně na reálných prvcích v Designeru.
 
 ## Nasazení
 
-Modul je součástí bundlu `dist/eldr.js`. Ten se ale v patičce webu zatím
-nenačítá — live jsou pořád samostatné skripty `index.min.js` a `sliders.min.js`
-na tagu `v1.2.27`. Než bannery pojedou, musí se patička přepnout na bundle.
+Site head i footer už ukazují na commit `f0200cd`, kde je modul součástí
+bundlu. Zbývá **publikovat web** — do té doby na živém webu běží pořád
+starý stav.
 
 Při editaci site head/footer **vždy nahrazuj celý obsah pole**, nikdy
-„jen tenhle blok" — viz incident 2026-08-15 v `_backup/FINDINGS.md`.
+„jen tenhle blok" — viz incident 2026-08-15 v `_backup/FINDINGS.md`. A vždy
+si aktuální stav vytáhni z API, ne ze zálohy v repu; ta byla 27. 8. o dva
+kroky pozadu a tvrdila, že patička jede na `v1.2.27`.
+
+### Po publikaci zkontrolovat
+
+1. `/inspirace/jak-vybrat-reklamni-pylon` — malý i velký banner sedí na
+   stejném místě jako dřív
+2. konzole prohlížeče je bez `[ELDR bannery]` hlášek
+3. klik na tlačítko banneru pošle do dataLayer `button_click`

--- a/docs/bannery-cms.md
+++ b/docs/bannery-cms.md
@@ -123,8 +123,9 @@ dokud nejsou přepsané. Až budou, jdou pryč (jsou i v `_backup/FINDINGS.md`).
 
 Site má Webflow Localization: primární `cs`, sekundární `en` a `de`.
 
-**Dnes je to rozbité.** Banner je zapečený v rich textu a nikdo ho nepřeložil,
-takže anglický i německý čtenář vidí český banner. Ověřeno na všech 24 URL.
+**Dnes není přeložený vůbec nic.** Ověřeno na všech 24 URL: `/en` i `/de`
+články jsou celé česky včetně bannerů. Rich text se nikdy nelokalizoval,
+mutace jen padají na primární češtinu.
 
 **Nově to funguje samo.** Kolekce Bannery je lokalizovaná jako každá jiná:
 přepneš locale, přepíšeš nadpis, text a tlačítko, publikuješ. Anglický
@@ -166,6 +167,9 @@ Zobrazí se až v náhledu publikovaného webu.
 
 Bannery jsou už v CMS, takže na článek zbývá jen: smazat odstavec
 s escapovaným HTML a napsat na jeho místo token. Pozice odpovídají živému webu.
+
+**Stačí přepsat 8 článků v české (primární) mutaci.** `/en` a `/de` dnes
+nemají vlastní text a padají na češtinu, takže token zdědí samy.
 
 | Článek (`/inspirace/…`) | Blok | Napsat do textu |
 |---|---|---|

--- a/docs/bannery-cms.md
+++ b/docs/bannery-cms.md
@@ -1,0 +1,142 @@
+# CMS Bannery — banner do článku bez ručního HTML
+
+Náhrada dnešního postupu, kdy se banner lepí do článku jako escapovaný HTML
+z Notionu ([Šablony bannerů v blogu](https://app.notion.com/p/3bd5ddfeb94f80ce8d32d27af35e3e2b)).
+
+## Proč pryč od embedu
+
+Dnešní banner v článku `/inspirace/jak-vybrat-reklamni-pylon`:
+
+```html
+<p>&lt;section fs-richtext-component=&quot;cta-small&quot; class=&quot;banner-cta-big&quot;&gt;…</p>
+```
+
+Co to obnáší:
+
+- Klient edituje kód. Jedna smazaná `&quot;` = rozbitý banner.
+- Obrázek se vkládá jako natvrdo opsaná CDN URL, tedy **bez `srcset`** —
+  do mobilu jde plná velikost. `alt` zůstává prázdný.
+- Do každého článku se kopíruje `id="w-node-_2a17c21a-…"`.
+- `fs-richtext-component="cta-small"` sedí i na velkém banneru (překlep
+  z kopírování).
+- Změna textu ve všech bannerech = ruční průchod všemi články.
+- Banner vykresluje Finsweet až po `DOMContentLoaded`, takže **GTM na jeho
+  tlačítko nikdy nesedne** — kliky z bannerů se dnes neměří.
+- Třídy bannerů audit tříd nevidí (jsou v escapovaném HTML) — proto byly
+  v prvním auditu označené za sirotky, viz `_backup/FINDINGS.md`.
+
+## Jak to funguje nově
+
+1. Banner je záznam v CMS kolekci **Bannery**.
+2. V článku se banner **vybere** v multi-reference poli.
+3. Na místo, kde má stát, klient napíše do textu odstavec `[banner:nazev]`.
+4. Šablona článku vykreslí vybrané bannery do skrytého zdroje ve správné
+   Webflow struktuře. Modul `src/modules/05-banners.js` je odtud vezme
+   a vymění za zástupný odstavec.
+
+Klient nikdy nevidí kód. Struktura banneru žije v Designeru, takže se dá
+kdykoli přestylovat na jednom místě a promítne se do všech článků.
+
+## Datový model — kolekce Bannery
+
+| Pole | Typ | Povinné | Platí pro |
+|---|---|---|---|
+| Name | Plain text | ano | interní název, klient ho vidí při výběru |
+| Slug | Slug | ano | klíč do `[banner:…]` |
+| Typ | Option: `Velký` / `Malý` | ano | řídí, která struktura se vykreslí |
+| Nadpis | Plain text | ano | oba |
+| Text | Plain text (víceřádkový) | ne | jen velký |
+| Text tlačítka | Plain text | ano | oba |
+| Odkaz tlačítka | Link | ano | oba |
+| Obrázek 1 | Image | ne | jen velký |
+| Popis obrázku 1 | Plain text | ne | jen velký (`alt`) |
+| Obrázek 2 | Image | ne | jen velký |
+| Popis obrázku 2 | Plain text | ne | jen velký (`alt`) |
+
+Pole rozdělit do **field groups** „Společné" a „Jen velký banner". Webflow
+neumí pole podle `Typ` schovávat, ale skupina s jasným názvem a help textem
+stačí — klient u malého banneru vyplní jen první skupinu.
+
+V kolekci **Inspirace** přibude jedno pole:
+
+| Pole | Typ | Cíl |
+|---|---|---|
+| Bannery v článku | Multi-reference | Bannery |
+
+## Nastavení v Designeru — šablona `/inspirace/`
+
+1. **Skrytý zdroj.** Na konec šablony vlož Div, custom atribut
+   `data-banner-source`, Display `none`. Skrytí musí být v Designeru —
+   kdyby skript nedojel, zdroj se nesmí ukázat. (Modul si `display: none`
+   pro jistotu nastaví i sám.)
+2. **Collection List** uvnitř, zdroj **Bannery v článku** (multi-reference
+   aktuální položky, ne celá kolekce — do HTML se tak dostanou jen bannery,
+   které článek opravdu používá).
+3. Na **Collection Item** dej custom atributy:
+   - `data-banner` → vazba na pole *Slug*
+   - `data-banner-typ` → vazba na pole *Typ* (jen pro čitelnost v DOM)
+4. Dovnitř položky vlož **dvě sekce** — `banner-cta-big` a `banner-cta-small`
+   ve stejné struktuře, jakou má dnešní embed, s poli navázanými na CMS.
+   Každé nastav **Conditional visibility**: `Typ = Velký`, resp. `Typ = Malý`.
+5. **Náhradní místo** (volitelné, ale doporučené): Div s atributem
+   `data-banner-fallback` pod poslední blok obsahu. Sem spadne banner, který
+   je vybraný v CMS, ale klient na něj v textu zapomněl napsat `[banner]`.
+   Bez něj takový banner tiše zmizí.
+
+### Na co si dát pozor
+
+- **Nepoužívej u obrázků grid child positioning.** Webflow z něj generuje
+  `id="w-node-…"` a to by se v článku duplikovalo. Obrázky umísti přes třídu
+  `banner-cta-big_image-wrapper` (flex), ne přes mřížku.
+- **Nechej `attributes-richtext@1` v site head**, dokud nejsou přepsané
+  všechny staré články. Nový systém ho nepotřebuje, ten starý na něm stojí.
+- Vnořený Collection List (multi-reference) zobrazí **max 5 položek**.
+  Na dva bannery v článku to bohatě stačí.
+- Kolekce Bannery se lokalizuje jako každá jiná — texty pro `/en` a `/de`
+  se vyplňují v příslušné locale.
+
+## Návod pro klienta
+
+**Nový banner:** CMS → Bannery → nový záznam. Vyplň název (podle něj banner
+poznáš), vyber typ, doplň nadpis, text tlačítka a odkaz. U velkého banneru
+navíc text a jednu nebo dvě fotky. Publikuj.
+
+**Banner do článku:**
+
+1. V článku dole v poli **Bannery v článku** zaškrtni ten, který tam chceš.
+2. V textu na místo, kde má banner stát, napiš **na samostatný řádek**:
+
+   ```
+   [banner:pylony-velky]
+   ```
+
+   `pylony-velky` je slug banneru (je vidět v CMS pod názvem).
+
+Zkrácený zápis: když napíšeš jen `[banner]`, vezme se další banner v pořadí,
+jak jsou zaškrtnuté. Dva bannery v článku = dvakrát `[banner]`, žádné slugy.
+
+Řádek `[banner:…]` musí být samostatný odstavec, ne uprostřed věty.
+Když se banner nenajde, odstavec se smaže — čtenář nikdy neuvidí hranaté
+závorky. Důvod je v konzoli prohlížeče.
+
+## Migrace stávajících článků
+
+24 URL v `/inspirace/` (8 článků × 3 jazyky). Postup na článek:
+
+1. Z embedu opiš nadpis, text, tlačítko a obrázky do nového záznamu Bannery.
+   Bannery se v článcích opakují — vznikne jich řádově pět, ne dvacet.
+2. Smaž odstavec s escapovaným HTML, napiš `[banner:…]`.
+3. Zaškrtni banner v poli Bannery v článku.
+
+Po dokončení jde z site head pryč `attributes-richtext@1` a **audit sirotků
+se dá zopakovat bez výjimky pro escapovaný HTML** — třídy bannerů budou
+konečně na reálných prvcích v Designeru.
+
+## Nasazení
+
+Modul je součástí bundlu `dist/eldr.js`. Ten se ale v patičce webu zatím
+nenačítá — live jsou pořád samostatné skripty `index.min.js` a `sliders.min.js`
+na tagu `v1.2.27`. Než bannery pojedou, musí se patička přepnout na bundle.
+
+Při editaci site head/footer **vždy nahrazuj celý obsah pole**, nikdy
+„jen tenhle blok" — viz incident 2026-08-15 v `_backup/FINDINGS.md`.

--- a/docs/bannery-cms.md
+++ b/docs/bannery-cms.md
@@ -37,6 +37,12 @@ Co to obnáší:
 stávajících článků. Klient nikdy nevidí kód a struktura banneru žije
 v Designeru, takže se dá kdykoli přestylovat na jednom místě.
 
+## Stav
+
+**Kolekce Bannery je založená a naplněná** (`6a90303011d6493faa8a946a`) — 15 záznamů
+vytažených ze živého webu, obrázky napojené na stávající assety. Zbývá postavit
+strukturu v Designeru a přepsat články.
+
 ## Datový model — kolekce Bannery
 
 | Pole | Typ | Povinné | Platí pro |
@@ -53,9 +59,9 @@ v Designeru, takže se dá kdykoli přestylovat na jednom místě.
 | Obrázek 2 | Image | ne | jen velký |
 | Popis obrázku 2 | Plain text | ne | jen velký |
 
-Pole rozdělit do **field groups** „Společné" a „Jen velký banner". Webflow
-neumí pole podle `Typ` schovávat, ale skupina s jasným názvem a help textem
-stačí — klient u malého banneru vyplní jen první skupinu.
+Pole jsou rozdělená do **field groups** „Společné" a „Jen velký banner"
+a každé má help text. Webflow neumí pole podle `Typ` schovávat, ale skupina
+s jasným názvem stačí — klient u malého banneru vyplní jen první skupinu.
 
 **Typ jde přepnout kdykoli zpětně.** Změna Option pole + publish a všechny
 články, které banner používají, se překreslí. Texty ani obrázky se nemažou,
@@ -78,17 +84,60 @@ jen se nepoužité pole přestane vykreslovat.
 5. Obrázkům nech **Loading: lazy**. Ve skrytém zdroji se pak nestahují;
    stáhnou se až po vložení do článku.
 
+### Pojmenování tříd (client-first)
+
+Dnešní třídy jsou ad hoc. Nová struktura se staví client-first:
+
+| dnes | client-first |
+|---|---|
+| `banner-cta-big` | `banner_component` |
+| `banner-cta-big-columns` | `banner_layout` |
+| `banner-cta-big_content` | `banner_content` |
+| `banner-cta-big_image-wrapper` | `banner_image-wrapper` |
+| `banner-cta-big-image` + `.left` / `.right` | `banner_image` + `is-left` / `is-right` |
+| `banner-cta-small` | `banner_component` + `is-small` |
+| `banner-cta-small_content` | `banner_content` + `is-small` |
+
+`contain`, `heading-style-h4`, `cta-section` a `button is-alternate` zůstávají —
+to už client-first je.
+
+**Aby vzhled zůstal identický:** ve Style panelu vyber prvek se starou třídou,
+v menu u názvu třídy dej **Duplicate class** (vznikne kopie se všemi
+vlastnostmi), přejmenuj ji na client-first název a starou třídu z prvku
+odeber. Nepřepisuj styly ručně, rozjede se to.
+
+**Staré třídy zatím nemazat** — drží vzhled bannerů ve starých článcích,
+dokud nejsou přepsané. Až budou, jdou pryč (jsou i v `_backup/FINDINGS.md`).
+
 ### Na co si dát pozor
 
 - **Nepoužívej u obrázků grid child positioning.** Webflow z něj generuje
   `id="w-node-…"` a to by se v článku duplikovalo. Obrázky umísti přes třídu
-  `banner-cta-big_image-wrapper` (flex), ne přes mřížku.
+  `banner_image-wrapper` (flex), ne přes mřížku.
 - **Nechej `attributes-richtext@1` v site head**, dokud nejsou přepsané
   všechny staré články. Nový systém ho nepotřebuje, ten starý na něm stojí.
-- Kolekce Bannery se lokalizuje jako každá jiná — texty pro `/en` a `/de`
-  se vyplňují v příslušné locale.
 - Držet kolekci v rozumné velikosti (do ~30 záznamů). HTML všech bannerů je
   na každé stránce článku, i když se použije jeden.
+
+## Jazykové mutace
+
+Site má Webflow Localization: primární `cs`, sekundární `en` a `de`.
+
+**Dnes je to rozbité.** Banner je zapečený v rich textu a nikdo ho nepřeložil,
+takže anglický i německý čtenář vidí český banner. Ověřeno na všech 24 URL.
+
+**Nově to funguje samo.** Kolekce Bannery je lokalizovaná jako každá jiná:
+přepneš locale, přepíšeš nadpis, text a tlačítko, publikuješ. Anglický
+čtenář dostane anglický banner v anglickém článku. Nevyplněné pole padá
+zpátky na češtinu, takže se nikdy nezobrazí prázdno.
+
+**Dvě pravidla, aby to drželo:**
+
+1. **Nelokalizuj pole Name a Slug.** Nech je ve všech mutacích česky —
+   jsou to klíče, na které míří `[banner:…]` v textu.
+2. **Nepřekládej token.** `[banner:pylony-velky]` zůstává v anglickém
+   i německém článku doslova stejný. Tohle je potřeba říct i překladateli
+   (a napsat do promptu, až bude blog překládat Claude).
 
 ## Návod pro klienta
 
@@ -115,11 +164,33 @@ Zobrazí se až v náhledu publikovaného webu.
 
 ## Migrace stávajících článků
 
-24 URL v `/inspirace/` (8 článků × 3 jazyky). Postup na článek:
+Bannery jsou už v CMS, takže na článek zbývá jen: smazat odstavec
+s escapovaným HTML a napsat na jeho místo token. Pozice odpovídají živému webu.
 
-1. Z embedu opiš nadpis, text, tlačítko a obrázky do nového záznamu Bannery.
-   Bannery se v článcích opakují — vznikne jich řádově pět, ne dvacet.
-2. Smaž odstavec s escapovaným HTML, napiš `[banner:…]`.
+| Článek (`/inspirace/…`) | Blok | Napsat do textu |
+|---|---|---|
+| `3d-napis-jak-ziskat-pozornost-zakazniku` | Obsah č. 2 | `[banner:3d-napisy-velky]` |
+| `3d-napis-jak-ziskat-pozornost-zakazniku` | Obsah č. 2 | `[banner:3d-napisy-maly]` |
+| `7-duvodu-proc-si-poridit-reklamni-totem-2` | Obsah č. 2 | `[banner:totemy-velky]` |
+| `7-duvodu-proc-si-poridit-reklamni-totem-2` | Obsah č. 2 | `[banner:totemy-maly]` |
+| `jak-vybrat-reklamni-pylon` | Obsah č. 2 | `[banner:pylony-maly]` |
+| `jak-vybrat-reklamni-pylon` | Obsah č. 2 | `[banner:pylony-velky]` |
+| `pozdvihnete-svuj-byznys-…-s-3d-reklamou-2` | Obsah č. 1 | `[banner:3d-reklama-velky]` |
+| `pozdvihnete-svuj-byznys-…-s-3d-reklamou-2` | Obsah č. 2 | `[banner:3d-reklama-maly]` |
+| `rezana-grafika-zaujmete-zakaznika-na-prvni-pohled` | Obsah č. 2 | `[banner:rezana-grafika-velky]` |
+| `rezana-grafika-zaujmete-zakaznika-na-prvni-pohled` | Obsah č. 2 | `[banner:rezana-grafika-maly]` |
+| `rozsvitte-svuj-brand-…-led-logo-dobrou-volbou` | Obsah č. 1 | `[banner:led-loga-maly]` |
+| `rozsvitte-svuj-brand-…-led-logo-dobrou-volbou` | Obsah č. 2 | `[banner:led-loga-velky]` |
+| `svetelna-reklama-propagujte-sve-podnikani-moderne` | Obsah č. 2 | `[banner:svetelna-reklama-maly]` |
+| `svetelne-napisy-nejlepsi-zpusob-…-podnikani` | Obsah č. 2 | `[banner:svetelne-napisy-velky]` |
+| `svetelne-napisy-nejlepsi-zpusob-…-podnikani` | Obsah č. 2 | `[banner:svetelne-napisy-maly]` |
+
+Kde jsou u jednoho článku dva bannery ve stejném bloku, jdou v uvedeném
+pořadí za sebou. Token se v EN a DE mutaci píše **stejně** (viz Jazykové mutace).
+
+`3D nápisy – velký` a `3D reklama – velký` mají shodný text a liší se jen
+fotkami — je to pozůstatek kopírování. Až budou články přepsané, dají se
+sloučit do jednoho záznamu.
 
 Po dokončení jde z site head pryč `attributes-richtext@1` a **audit sirotků
 se dá zopakovat bez výjimky pro escapovaný HTML** — třídy bannerů budou

--- a/docs/bannery-cms.md
+++ b/docs/bannery-cms.md
@@ -27,22 +27,22 @@ Co to obnáší:
 
 ## Jak to funguje nově
 
-1. Banner je záznam v CMS kolekci **Bannery**.
-2. V článku se banner **vybere** v multi-reference poli.
-3. Na místo, kde má stát, klient napíše do textu odstavec `[banner:nazev]`.
-4. Šablona článku vykreslí vybrané bannery do skrytého zdroje ve správné
-   Webflow struktuře. Modul `src/modules/05-banners.js` je odtud vezme
-   a vymění za zástupný odstavec.
+1. Banner je záznam v CMS kolekci **Bannery** — klient má knihovnu.
+2. Šablona článku vykreslí **celou kolekci** do skrytého zdroje ve správné
+   Webflow struktuře.
+3. Klient napíše do textu článku `[banner:nazev-banneru]`.
+4. Modul `src/modules/05-banners.js` vymění token za hotový banner.
 
-Klient nikdy nevidí kód. Struktura banneru žije v Designeru, takže se dá
-kdykoli přestylovat na jednom místě a promítne se do všech článků.
+**V kolekci Inspirace se nemění vůbec nic.** Žádné nové pole, žádná změna
+stávajících článků. Klient nikdy nevidí kód a struktura banneru žije
+v Designeru, takže se dá kdykoli přestylovat na jednom místě.
 
 ## Datový model — kolekce Bannery
 
 | Pole | Typ | Povinné | Platí pro |
 |---|---|---|---|
-| Name | Plain text | ano | interní název, klient ho vidí při výběru |
-| Slug | Slug | ano | klíč do `[banner:…]` |
+| Name | Plain text | ano | název banneru, píše se do `[banner:…]` |
+| Slug | Slug | ano | druhý funkční klíč do `[banner:…]` |
 | Typ | Option: `Velký` / `Malý` | ano | řídí, která struktura se vykreslí |
 | Nadpis | Plain text | ano | oba |
 | Text | Plain text (víceřádkový) | ne | jen velký |
@@ -51,37 +51,32 @@ kdykoli přestylovat na jednom místě a promítne se do všech článků.
 | Obrázek 1 | Image | ne | jen velký |
 | Popis obrázku 1 | Plain text | ne | jen velký (`alt`) |
 | Obrázek 2 | Image | ne | jen velký |
-| Popis obrázku 2 | Plain text | ne | jen velký (`alt`) |
+| Popis obrázku 2 | Plain text | ne | jen velký |
 
 Pole rozdělit do **field groups** „Společné" a „Jen velký banner". Webflow
 neumí pole podle `Typ` schovávat, ale skupina s jasným názvem a help textem
 stačí — klient u malého banneru vyplní jen první skupinu.
 
-V kolekci **Inspirace** přibude jedno pole:
-
-| Pole | Typ | Cíl |
-|---|---|---|
-| Bannery v článku | Multi-reference | Bannery |
+**Typ jde přepnout kdykoli zpětně.** Změna Option pole + publish a všechny
+články, které banner používají, se překreslí. Texty ani obrázky se nemažou,
+jen se nepoužité pole přestane vykreslovat.
 
 ## Nastavení v Designeru — šablona `/inspirace/`
 
 1. **Skrytý zdroj.** Na konec šablony vlož Div, custom atribut
    `data-banner-source`, Display `none`. Skrytí musí být v Designeru —
-   kdyby skript nedojel, zdroj se nesmí ukázat. (Modul si `display: none`
+   kdyby skript nedojel, knihovna se nesmí ukázat. (Modul si `display: none`
    pro jistotu nastaví i sám.)
-2. **Collection List** uvnitř, zdroj **Bannery v článku** (multi-reference
-   aktuální položky, ne celá kolekce — do HTML se tak dostanou jen bannery,
-   které článek opravdu používá).
+2. **Collection List** uvnitř, zdroj **Bannery** (celá kolekce, bez filtru).
+   Limit nech na 100.
 3. Na **Collection Item** dej custom atributy:
    - `data-banner` → vazba na pole *Slug*
-   - `data-banner-typ` → vazba na pole *Typ* (jen pro čitelnost v DOM)
+   - `data-banner-name` → vazba na pole *Name*
 4. Dovnitř položky vlož **dvě sekce** — `banner-cta-big` a `banner-cta-small`
    ve stejné struktuře, jakou má dnešní embed, s poli navázanými na CMS.
    Každé nastav **Conditional visibility**: `Typ = Velký`, resp. `Typ = Malý`.
-5. **Náhradní místo** (volitelné, ale doporučené): Div s atributem
-   `data-banner-fallback` pod poslední blok obsahu. Sem spadne banner, který
-   je vybraný v CMS, ale klient na něj v textu zapomněl napsat `[banner]`.
-   Bez něj takový banner tiše zmizí.
+5. Obrázkům nech **Loading: lazy**. Ve skrytém zdroji se pak nestahují;
+   stáhnou se až po vložení do článku.
 
 ### Na co si dát pozor
 
@@ -90,34 +85,33 @@ V kolekci **Inspirace** přibude jedno pole:
   `banner-cta-big_image-wrapper` (flex), ne přes mřížku.
 - **Nechej `attributes-richtext@1` v site head**, dokud nejsou přepsané
   všechny staré články. Nový systém ho nepotřebuje, ten starý na něm stojí.
-- Vnořený Collection List (multi-reference) zobrazí **max 5 položek**.
-  Na dva bannery v článku to bohatě stačí.
 - Kolekce Bannery se lokalizuje jako každá jiná — texty pro `/en` a `/de`
   se vyplňují v příslušné locale.
+- Držet kolekci v rozumné velikosti (do ~30 záznamů). HTML všech bannerů je
+  na každé stránce článku, i když se použije jeden.
 
 ## Návod pro klienta
 
-**Nový banner:** CMS → Bannery → nový záznam. Vyplň název (podle něj banner
-poznáš), vyber typ, doplň nadpis, text tlačítka a odkaz. U velkého banneru
-navíc text a jednu nebo dvě fotky. Publikuj.
+**Nový banner:** CMS → Bannery → nový záznam. Vyplň název, vyber typ, doplň
+nadpis, text tlačítka a odkaz. U velkého banneru navíc text a jednu nebo dvě
+fotky. Publikuj.
 
-**Banner do článku:**
+**Banner do článku:** do textu na místo, kde má banner stát, napiš:
 
-1. V článku dole v poli **Bannery v článku** zaškrtni ten, který tam chceš.
-2. V textu na místo, kde má banner stát, napiš **na samostatný řádek**:
+```
+[banner:Pylony – velký]
+```
 
-   ```
-   [banner:pylony-velky]
-   ```
+Píše se název banneru z CMS. Na diakritice, velikosti písmen ani mezerách
+nezáleží — `[banner:pylony-velky]` i `[banner: Pylony – velký ]` najdou totéž.
 
-   `pylony-velky` je slug banneru (je vidět v CMS pod názvem).
+Token může být na samostatném řádku i uprostřed věty; banner se vždycky
+vloží až za daný odstavec, aby nerozbil text. Když se banner nenajde, token
+se z textu smaže (čtenář nikdy neuvidí hranaté závorky) a důvod je v konzoli
+prohlížeče.
 
-Zkrácený zápis: když napíšeš jen `[banner]`, vezme se další banner v pořadí,
-jak jsou zaškrtnuté. Dva bannery v článku = dvakrát `[banner]`, žádné slugy.
-
-Řádek `[banner:…]` musí být samostatný odstavec, ne uprostřed věty.
-Když se banner nenajde, odstavec se smaže — čtenář nikdy neuvidí hranaté
-závorky. Důvod je v konzoli prohlížeče.
+**Ve Webflow Editoru banner neuvidíš** — tam zůstane jen `[banner:…]`.
+Zobrazí se až v náhledu publikovaného webu.
 
 ## Migrace stávajících článků
 
@@ -126,7 +120,6 @@ závorky. Důvod je v konzoli prohlížeče.
 1. Z embedu opiš nadpis, text, tlačítko a obrázky do nového záznamu Bannery.
    Bannery se v článcích opakují — vznikne jich řádově pět, ne dvacet.
 2. Smaž odstavec s escapovaným HTML, napiš `[banner:…]`.
-3. Zaškrtni banner v poli Bannery v článku.
 
 Po dokončení jde z site head pryč `attributes-richtext@1` a **audit sirotků
 se dá zopakovat bez výjimky pro escapovaný HTML** — třídy bannerů budou

--- a/src/modules/05-banners.js
+++ b/src/modules/05-banners.js
@@ -1,0 +1,141 @@
+/* ==========================================================================
+   Bannery z CMS — vložení do článku bez ručního HTML
+   --------------------------------------------------------------------------
+   Dnešní stav: banner se do článku vlepuje jako escapovaný HTML do rich textu
+   (`&lt;section class=&quot;banner-cta-big&quot;…`) a Finsweet
+   `attributes-richtext` ho na klientovi rozbalí. Klient tím pádem edituje kód
+   — přepisuje třídy, ručně lepí URL obrázků a kopíruje `w-node-…` id. Každý
+   překlep je rozbitý banner a obrázky jdou bez srcset v plné velikosti.
+
+   Nově je banner záznam v CMS kolekci Bannery. Šablona článku ho vykreslí do
+   skrytého zdroje `[data-banner-source]` ve správné Webflow struktuře (živé
+   třídy, responzivní srcset, alt texty). V textu článku zůstane jen zástupný
+   odstavec `[banner:nazev]`, který tenhle modul vymění za hotový banner.
+
+   Kontrakt se šablonou (podrobně v docs/bannery-cms.md):
+     [data-banner-source]    skrytý wrapper s Collection Listem kolekce Bannery
+     [data-banner="slug"]    položka seznamu, uvnitř hotová struktura banneru
+     [data-banner-fallback]  volitelné místo pro banner, na který se v textu
+                             zapomnělo (bez něj se takový banner nevykreslí)
+
+   POŘADÍ V BUNDLU — proto 05, hned za jádrem:
+   - před 10-vars → tokeny {#YOE#} se doplní i do vloženého banneru
+   - před 90-gtm  → na tlačítko banneru stihne sednout měření button_click
+     (dnes na něm neměří nic: Finsweet ho vykreslí až po DOMContentLoaded)
+   ========================================================================== */
+
+(function () {
+  var SOURCE = '[data-banner-source]';
+  var FALLBACK = '[data-banner-fallback]';
+  var ITEM = '[data-banner]';
+  var RICH = '.w-richtext';
+
+  /* `[banner:nazev-banneru]`, nebo holé `[banner]` = vezmi další v pořadí,
+     jak jsou vybrané v CMS. Mezery kolem dvojtečky se odpouštějí, velikost
+     písmen taky — klient píše do textového pole, ne do kódu. */
+  var TOKEN = /^\[banner(?:\s*:\s*([^\]]+))?\]$/i;
+
+  var source = $1(SOURCE);
+  if (!source) return;
+
+  /* Skrytí patří do Designeru (kdyby skript nedojel, nesmí se zdroj ukázat).
+     Tady je jen pojistka proti tomu, aby ho někdo ve Webflow omylem odkryl. */
+  source.style.display = 'none';
+
+  function warn(message) {
+    if (window.console && console.warn) console.warn('[ELDR bannery] ' + message);
+  }
+
+  /* Webflow nechává v HTML i prvky schované podmíněnou viditelností
+     (`w-condition-invisible`) a prvky s prázdným CMS polem
+     (`w-dyn-bind-empty`) — typicky druhý obrázek, který se vyplňovat nemusí. */
+  function isDropped(el) {
+    return el.classList.contains('w-condition-invisible') ||
+      el.classList.contains('w-dyn-bind-empty');
+  }
+
+  /* Klonuje se OBSAH položky, ne položka samotná — ta nese `w-dyn-item`
+     a `role="listitem"`, co v článku nemá co dělat. */
+  function build(item) {
+    var frag = document.createDocumentFragment();
+
+    Array.prototype.slice.call(item.children).forEach(function (child) {
+      if (isDropped(child)) return;
+      var clone = child.cloneNode(true);
+      $$('.w-condition-invisible, .w-dyn-bind-empty', clone).forEach(function (el) {
+        if (el.parentNode) el.parentNode.removeChild(el);
+      });
+      frag.appendChild(clone);
+    });
+
+    return frag.childNodes.length ? frag : null;
+  }
+
+  var items = $$(ITEM, source).filter(function (item) { return !isDropped(item); });
+  var used = [];
+
+  function slugOf(item) {
+    return (item.getAttribute('data-banner') || '').trim().toLowerCase();
+  }
+
+  function take(name) {
+    var i;
+    if (name) {
+      for (i = 0; i < items.length; i++) {
+        if (slugOf(items[i]) === name) return items[i];
+      }
+      return null;
+    }
+    for (i = 0; i < items.length; i++) {
+      if (used.indexOf(items[i]) === -1) return items[i];
+    }
+    return null;
+  }
+
+  /* Zástupný odstavec musí být v odstavci sám. Banner je <section>, uvnitř
+     <p> by byl neplatný HTML a prohlížeč by ho z odstavce stejně vystrčil. */
+  function placeholders() {
+    var found = [];
+    $$(RICH).forEach(function (rich) {
+      if (source.contains(rich)) return;
+      $$('p', rich).forEach(function (p) {
+        var match = TOKEN.exec((p.textContent || '').trim());
+        if (match) found.push({ el: p, name: (match[1] || '').trim().toLowerCase() });
+      });
+    });
+    return found;
+  }
+
+  onReady(function () {
+    placeholders().forEach(function (slot) {
+      var item = take(slot.name);
+      var banner = item && build(item);
+
+      if (banner) {
+        slot.el.parentNode.insertBefore(banner, slot.el);
+        if (used.indexOf(item) === -1) used.push(item);
+      } else if (slot.name) {
+        warn('banner „' + slot.name + '" v článku není vybraný nebo v CMS neexistuje');
+      } else {
+        warn('v textu je [banner] navíc — v CMS už žádný další nezbyl');
+      }
+
+      /* Zástupný odstavec mizí vždycky. I když se banner nenajde, čtenář
+         nesmí v textu vidět holé `[banner:…]`. */
+      slot.el.parentNode.removeChild(slot.el);
+    });
+
+    /* Banner vybraný v CMS, na který se v textu zapomnělo. Bez záchytného
+       místa by tiše zmizel a nikdo by si toho nevšiml. */
+    var fallback = $1(FALLBACK);
+    if (!fallback) return;
+
+    items.forEach(function (item) {
+      if (used.indexOf(item) !== -1) return;
+      var banner = build(item);
+      if (!banner) return;
+      warn('banner „' + slugOf(item) + '" nemá v textu [banner:…], vykreslil se na náhradní místo');
+      fallback.appendChild(banner);
+    });
+  });
+})();

--- a/src/modules/05-banners.js
+++ b/src/modules/05-banners.js
@@ -7,16 +7,17 @@
    — přepisuje třídy, ručně lepí URL obrázků a kopíruje `w-node-…` id. Každý
    překlep je rozbitý banner a obrázky jdou bez srcset v plné velikosti.
 
-   Nově je banner záznam v CMS kolekci Bannery. Šablona článku ho vykreslí do
-   skrytého zdroje `[data-banner-source]` ve správné Webflow struktuře (živé
-   třídy, responzivní srcset, alt texty). V textu článku zůstane jen zástupný
-   odstavec `[banner:nazev]`, který tenhle modul vymění za hotový banner.
+   Nově je banner záznam v CMS kolekci Bannery. Šablona článku vykreslí CELOU
+   kolekci do skrytého zdroje `[data-banner-source]` ve správné Webflow
+   struktuře (živé třídy, responzivní srcset, alt texty) — funguje tedy jako
+   knihovna. V kolekci Inspirace se nemění nic; klient jen napíše do textu
+   `[banner:nazev]` a modul to vymění za hotový banner.
 
    Kontrakt se šablonou (podrobně v docs/bannery-cms.md):
-     [data-banner-source]    skrytý wrapper s Collection Listem kolekce Bannery
-     [data-banner="slug"]    položka seznamu, uvnitř hotová struktura banneru
-     [data-banner-fallback]  volitelné místo pro banner, na který se v textu
-                             zapomnělo (bez něj se takový banner nevykreslí)
+     [data-banner-source]   skrytý wrapper s Collection Listem kolekce Bannery
+     [data-banner="slug"]   položka seznamu, uvnitř hotová struktura banneru
+     [data-banner-name]     Název banneru — druhý klíč, aby klient nemusel
+                            hlídat slug a mohl napsat i „Pylony – velký"
 
    POŘADÍ V BUNDLU — proto 05, hned za jádrem:
    - před 10-vars → tokeny {#YOE#} se doplní i do vloženého banneru
@@ -26,24 +27,33 @@
 
 (function () {
   var SOURCE = '[data-banner-source]';
-  var FALLBACK = '[data-banner-fallback]';
   var ITEM = '[data-banner]';
   var RICH = '.w-richtext';
+  var BLOCKS = 'p, li, blockquote, h1, h2, h3, h4, h5, h6';
 
-  /* `[banner:nazev-banneru]`, nebo holé `[banner]` = vezmi další v pořadí,
-     jak jsou vybrané v CMS. Mezery kolem dvojtečky se odpouštějí, velikost
-     písmen taky — klient píše do textového pole, ne do kódu. */
-  var TOKEN = /^\[banner(?:\s*:\s*([^\]]+))?\]$/i;
+  /* `[banner:nazev]`. Mezery kolem dvojtečky se odpouštějí, diakritika
+     a velikost písmen taky — klient píše do textového pole, ne do kódu.
+     Název je nepovinný jen proto, aby se holé `[banner]` dalo z textu uklidit
+     a nezůstalo na očích čtenáři. */
+  var TOKEN = /\[banner\s*(?::\s*([^\]\r\n]+))?\]/gi;
 
   var source = $1(SOURCE);
   if (!source) return;
 
-  /* Skrytí patří do Designeru (kdyby skript nedojel, nesmí se zdroj ukázat).
-     Tady je jen pojistka proti tomu, aby ho někdo ve Webflow omylem odkryl. */
+  /* Skrytí patří do Designeru (kdyby skript nedojel, nesmí se knihovna
+     ukázat). Tady je jen pojistka, aby ji někdo ve Webflow omylem neodkryl. */
   source.style.display = 'none';
 
   function warn(message) {
     if (window.console && console.warn) console.warn('[ELDR bannery] ' + message);
+  }
+
+  /* „Pylony – velký", „pylony-velky" i „Pylony velky" musí vést na stejný
+     banner. Bez toho by klient musel opisovat slug znak po znaku. */
+  function key(value) {
+    var text = (value || '').trim().toLowerCase();
+    if (text.normalize) text = text.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+    return text.replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
   }
 
   /* Webflow nechává v HTML i prvky schované podmíněnou viditelností
@@ -71,71 +81,79 @@
     return frag.childNodes.length ? frag : null;
   }
 
-  var items = $$(ITEM, source).filter(function (item) { return !isDropped(item); });
-  var used = [];
+  var library = {};
 
-  function slugOf(item) {
-    return (item.getAttribute('data-banner') || '').trim().toLowerCase();
-  }
-
-  function take(name) {
-    var i;
-    if (name) {
-      for (i = 0; i < items.length; i++) {
-        if (slugOf(items[i]) === name) return items[i];
-      }
-      return null;
-    }
-    for (i = 0; i < items.length; i++) {
-      if (used.indexOf(items[i]) === -1) return items[i];
-    }
-    return null;
-  }
-
-  /* Zástupný odstavec musí být v odstavci sám. Banner je <section>, uvnitř
-     <p> by byl neplatný HTML a prohlížeč by ho z odstavce stejně vystrčil. */
-  function placeholders() {
-    var found = [];
-    $$(RICH).forEach(function (rich) {
-      if (source.contains(rich)) return;
-      $$('p', rich).forEach(function (p) {
-        var match = TOKEN.exec((p.textContent || '').trim());
-        if (match) found.push({ el: p, name: (match[1] || '').trim().toLowerCase() });
-      });
+  $$(ITEM, source).forEach(function (item) {
+    if (isDropped(item)) return;
+    [item.getAttribute('data-banner'), item.getAttribute('data-banner-name')].forEach(function (name) {
+      var k = key(name);
+      if (k && !library[k]) library[k] = item;
     });
-    return found;
+  });
+
+  /* Token se z textu odstraňuje po textových uzlech, ne přes innerHTML —
+     odkazy a tučný text uvnitř odstavce musí zůstat nedotčené. */
+  function stripTokens(block) {
+    var walker = document.createTreeWalker(block, NodeFilter.SHOW_TEXT, null);
+    var nodes = [];
+    var node;
+    while ((node = walker.nextNode())) nodes.push(node);
+    nodes.forEach(function (text) {
+      if (text.nodeValue.indexOf('[') === -1) return;
+      TOKEN.lastIndex = 0;
+      text.nodeValue = text.nodeValue.replace(TOKEN, '');
+    });
+  }
+
+  function process(block) {
+    var text = block.textContent || '';
+    if (text.indexOf('[') === -1) return;
+
+    var frags = [];
+    var match;
+
+    TOKEN.lastIndex = 0;
+    while ((match = TOKEN.exec(text))) {
+      var name = key(match[1]);
+
+      if (!name) {
+        warn('v textu je [banner] bez názvu — nevím, který vložit');
+        continue;
+      }
+
+      var item = library[name];
+      if (!item) {
+        warn('banner „' + name + '" v kolekci Bannery neexistuje nebo není publikovaný');
+        continue;
+      }
+
+      var banner = build(item);
+      if (banner) frags.push(banner);
+    }
+
+    /* Token mizí z textu vždycky. I když se banner nenajde, čtenář nesmí
+       v článku vidět holé `[banner:…]`. */
+    stripTokens(block);
+
+    /* Banner smí být sourozenec odstavce, ne jeho obsah — <section> uvnitř
+       <p> je neplatný HTML a prohlížeč by ho z odstavce stejně vystrčil. */
+    var anchor = block;
+    frags.forEach(function (frag) {
+      var last = frag.lastChild;
+      anchor.parentNode.insertBefore(frag, anchor.nextSibling);
+      anchor = last;
+    });
+
+    /* Odstavec, ve kterém byl jen token, po úklidu zůstal prázdný. */
+    if (!block.textContent.trim() && !block.children.length && block.parentNode) {
+      block.parentNode.removeChild(block);
+    }
   }
 
   onReady(function () {
-    placeholders().forEach(function (slot) {
-      var item = take(slot.name);
-      var banner = item && build(item);
-
-      if (banner) {
-        slot.el.parentNode.insertBefore(banner, slot.el);
-        if (used.indexOf(item) === -1) used.push(item);
-      } else if (slot.name) {
-        warn('banner „' + slot.name + '" v článku není vybraný nebo v CMS neexistuje');
-      } else {
-        warn('v textu je [banner] navíc — v CMS už žádný další nezbyl');
-      }
-
-      /* Zástupný odstavec mizí vždycky. I když se banner nenajde, čtenář
-         nesmí v textu vidět holé `[banner:…]`. */
-      slot.el.parentNode.removeChild(slot.el);
-    });
-
-    /* Banner vybraný v CMS, na který se v textu zapomnělo. Bez záchytného
-       místa by tiše zmizel a nikdo by si toho nevšiml. */
-    var fallback = $1(FALLBACK);
-    if (!fallback) return;
-
-    items.forEach(function (item) {
-      if (used.indexOf(item) !== -1) return;
-      var banner = build(item);
-      if (!banner) return;
-      warn('banner „' + slugOf(item) + '" nemá v textu [banner:…], vykreslil se na náhradní místo');
-      fallback.appendChild(banner);
+    $$(RICH).forEach(function (rich) {
+      if (source.contains(rich)) return;
+      $$(BLOCKS, rich).forEach(process);
     });
   });
 })();

--- a/src/modules/05-banners.js
+++ b/src/modules/05-banners.js
@@ -14,10 +14,18 @@
    `[banner:nazev]` a modul to vymění za hotový banner.
 
    Kontrakt se šablonou (podrobně v docs/bannery-cms.md):
-     [data-banner-source]   skrytý wrapper s Collection Listem kolekce Bannery
-     [data-banner="slug"]   položka seznamu, uvnitř hotová struktura banneru
-     [data-banner-name]     Název banneru — druhý klíč, aby klient nemusel
-                            hlídat slug a mohl napsat i „Pylony – velký"
+     [data-banner-source]     skrytý wrapper s Collection Listem kolekce Bannery
+     .banner-item             položka knihovny; její id = slug banneru
+     .banner-name             skrytý text s Názvem — druhý klíč, aby klient
+                              nemusel hlídat slug a mohl napsat „Pylony – velký"
+     [data-banner-variant]    velký / malý provedení uvnitř položky
+
+   Proč id a skrytý text místo data atributů: Webflow Data API neumí na
+   položce Collection Listu navázat custom atribut na CMS pole. Navázat jde
+   DOM id a text, takže klíče jedou přes ně. Stejný důvod má i výběr varianty
+   — podmíněná viditelnost přes API nejde nastavit na Option pole, takže
+   šablona vykreslí obě provedení, Webflow to nepoužité označí
+   `w-condition-invisible` (podle přepínače Velký banner) a vybere se tady.
 
    POŘADÍ V BUNDLU — proto 05, hned za jádrem:
    - před 10-vars → tokeny {#YOE#} se doplní i do vloženého banneru
@@ -27,7 +35,9 @@
 
 (function () {
   var SOURCE = '[data-banner-source]';
-  var ITEM = '[data-banner]';
+  var ITEM = '.banner-item';
+  var NAME = '.banner-name';
+  var VARIANT = '[data-banner-variant]';
   var RICH = '.w-richtext';
   var BLOCKS = 'p, li, blockquote, h1, h2, h3, h4, h5, h6';
 
@@ -64,28 +74,30 @@
       el.classList.contains('w-dyn-bind-empty');
   }
 
-  /* Klonuje se OBSAH položky, ne položka samotná — ta nese `w-dyn-item`
-     a `role="listitem"`, co v článku nemá co dělat. */
+  /* Klonuje se jen vybrané provedení, ne celá položka — ta nese obal
+     Collection Listu a skrytý nosič názvu, co v článku nemá co dělat.
+     V DOM je velký první, takže když ho přepínač nechá projít, vyhraje. */
   function build(item) {
-    var frag = document.createDocumentFragment();
+    var chosen = $$(VARIANT, item).filter(function (el) { return !isDropped(el); })[0];
+    if (!chosen) return null;
 
-    Array.prototype.slice.call(item.children).forEach(function (child) {
-      if (isDropped(child)) return;
-      var clone = child.cloneNode(true);
-      $$('.w-condition-invisible, .w-dyn-bind-empty', clone).forEach(function (el) {
-        if (el.parentNode) el.parentNode.removeChild(el);
-      });
-      frag.appendChild(clone);
+    var clone = chosen.cloneNode(true);
+    clone.removeAttribute('data-banner-variant');
+    $$('.w-condition-invisible, .w-dyn-bind-empty', clone).forEach(function (el) {
+      if (el.parentNode) el.parentNode.removeChild(el);
     });
 
-    return frag.childNodes.length ? frag : null;
+    var frag = document.createDocumentFragment();
+    frag.appendChild(clone);
+    return frag;
   }
 
   var library = {};
 
   $$(ITEM, source).forEach(function (item) {
     if (isDropped(item)) return;
-    [item.getAttribute('data-banner'), item.getAttribute('data-banner-name')].forEach(function (name) {
+    var named = $1(NAME, item);
+    [item.id, named && named.textContent].forEach(function (name) {
       var k = key(name);
       if (k && !library[k]) library[k] = item;
     });

--- a/src/modules/60-ai-share.js
+++ b/src/modules/60-ai-share.js
@@ -4,7 +4,11 @@
    ========================================================================== */
 
 (function () {
-  var scope = $1('[data-ai-share]');
+  /* Hák je ve Webflow zapsaný jako DOM id, ne jako custom atribut
+     (`<div id="data-ai-share">`). Selektor `[data-ai-share]` na id nesedí,
+     takže se modul tiše vypnul a tlačítka zůstala na href="#" — klik pak
+     nedělal nic. Bereme obojí, ať na tom volba pole ve Webflow nestojí. */
+  var scope = $1('[data-ai-share], #data-ai-share');
   if (!scope) return;
 
   var pageUrl = location.href.split('#')[0];

--- a/test/smoke.js
+++ b/test/smoke.js
@@ -120,7 +120,84 @@ run('Anglická mutace téže stránky (regrese detekce jazyka)',
       doc.querySelector('.reference_item-language').textContent === 'Translated from German');
   });
 
-// --- 4. prázdná stránka ---------------------------------------------------
+// --- 4. bannery z CMS -----------------------------------------------------
+// Šablona článku vykreslí bannery do skrytého zdroje, v textu zůstane jen
+// zástupný odstavec. Fixture kopíruje skutečný výstup Webflow Collection
+// Listu včetně `w-dyn-bind-empty` na nevyplněném druhém obrázku.
+const BANNER_SOURCE = `
+  <div data-banner-source style="display:none"><div class="w-dyn-list"><div role="list" class="w-dyn-items">
+    <div role="listitem" class="w-dyn-item" data-banner="pylony-velky">
+      <section class="banner-cta-big"><div class="banner-cta-big_content">
+        <h2 class="heading-style-h4">Pylony, které upoutají</h2>
+        <a href="/kontakty" class="button is-alternate cta-section w-button">Cenová nabídka</a>
+      </div><div class="banner-cta-big_image-wrapper">
+        <img class="banner-cta-big-image left" src="a.webp" alt="Pylon">
+        <img class="banner-cta-big-image right w-dyn-bind-empty">
+      </div></section>
+    </div>
+    <div role="listitem" class="w-dyn-item" data-banner="pylony-maly">
+      <section class="banner-cta-small"><h2 class="heading-style-h4 cta-section">Malý banner</h2></section>
+    </div>
+    <div role="listitem" class="w-dyn-item" data-banner="zapomenuty">
+      <section class="banner-cta-small"><h2 class="heading-style-h4 cta-section">Zapomenutý</h2></section>
+    </div>
+  </div></div></div>`;
+
+run('Bannery z CMS (zástupný text v rich textu)',
+  `${BANNER_SOURCE}
+   <div class="w-richtext"><p>Úvodní odstavec.</p><p>[banner:Pylony-Velky]</p></div>
+   <div class="w-richtext"><p>[banner]</p><p>[banner:neexistuje]</p><p>Závěr.</p></div>
+   <div data-banner-fallback></div>`,
+  'https://www.eldr.cz/inspirace/jak-vybrat-reklamni-pylon',
+  (win, doc) => {
+    const rich = doc.querySelectorAll('.w-richtext');
+    ok('pojmenovaný banner sedí v prvním rich textu', rich[0].querySelectorAll('.banner-cta-big').length === 1);
+    ok('název banneru je case-insensitive', !!rich[0].querySelector('.banner-cta-big'));
+    ok('holé [banner] vzalo další nepoužitý v pořadí', rich[1].querySelectorAll('.banner-cta-small').length === 1);
+    ok('banner je vložen PŘED zástupný odstavec, ne na konec',
+      rich[0].firstElementChild.tagName === 'P' && rich[0].children[1].classList.contains('banner-cta-big'));
+
+    ok('žádný [banner…] nezůstal na stránce viditelný', !/\[banner/i.test(doc.body.textContent));
+    ok('nenalezený banner odstavec smazal, ne vypsal', rich[1].querySelectorAll('p').length === 1);
+
+    // Nevyplněný druhý obrázek nesmí skončit v článku jako <img> bez src.
+    const big = rich[0].querySelector('.banner-cta-big');
+    ok('prázdné CMS pole (druhý obrázek) se nevykreslí', big.querySelectorAll('img').length === 1);
+    ok('vyplněný obrázek zůstal i s alt textem', big.querySelector('img').getAttribute('alt') === 'Pylon');
+
+    // Klon nesmí táhnout do článku obal Webflow seznamu.
+    ok('klon nenese w-dyn-item ani role="listitem"',
+      !big.closest('.w-dyn-item') && !rich[0].querySelector('[role="listitem"]'));
+
+    const fallback = doc.querySelector('[data-banner-fallback]');
+    ok('banner bez [banner:…] v textu spadl na náhradní místo',
+      fallback.querySelectorAll('.banner-cta-small').length === 1);
+    ok('náhradní místo dostalo právě ten zapomenutý',
+      /Zapomenutý/.test(fallback.textContent));
+
+    // Zdroj zůstává skrytý a nedotčený — vykresluje se z klonů.
+    const src = doc.querySelector('[data-banner-source]');
+    ok('zdroj zůstal skrytý', src.style.display === 'none');
+    ok('zdroj si nechal všechny tři položky', src.querySelectorAll('[data-banner]').length === 3);
+
+    // Bannery se vkládají v modulu 05, měření sedá v modulu 90 — tlačítko
+    // banneru se tím poprvé vůbec dostane do GTM.
+    win.dataLayer = [];
+    big.querySelector('.button').click();
+    const ev = win.dataLayer.filter(e => e.event === 'button_click');
+    ok('GTM měří tlačítko vloženého banneru', ev.length === 1 && ev[0].button_text === 'Cenová nabídka');
+  });
+
+run('Článek bez zdroje bannerů (modul se musí vypnout)',
+  '<div class="w-richtext"><p>[banner:pylony-velky]</p></div>',
+  'https://www.eldr.cz/inspirace/rezana-grafika-zaujmete-zakaznika-na-prvni-pohled',
+  (win, doc) => {
+    // Bez `[data-banner-source]` modul nesmí sáhnout na text. Chybějící
+    // zdroj je chyba šablony, ne důvod mazat obsah článku.
+    ok('text článku zůstal nedotčený', doc.querySelector('.w-richtext p').textContent === '[banner:pylony-velky]');
+  });
+
+// --- 5. prázdná stránka ---------------------------------------------------
 run('Prázdná stránka (moduly se musí samy vypnout)', '<div></div>', 'https://www.eldr.cz/404', () => {});
 
 console.log(`\n${pass} prošlo, ${fail} selhalo`);

--- a/test/smoke.js
+++ b/test/smoke.js
@@ -126,19 +126,35 @@ run('Anglická mutace téže stránky (regrese detekce jazyka)',
 // Collection Listu včetně `w-dyn-bind-empty` na nevyplněném druhém obrázku
 // a `w-condition-invisible` na struktuře, kterou vypnula podmíněná viditelnost.
 const BANNER_SOURCE = `
-  <div data-banner-source style="display:none"><div class="w-dyn-list"><div role="list" class="w-dyn-items">
-    <div role="listitem" class="w-dyn-item" data-banner="pylony-velky" data-banner-name="Pylony – velký">
-      <section class="banner-cta-big"><div class="banner-cta-big_content">
-        <h2 class="heading-style-h4">Pylony, které upoutají</h2>
-        <a href="/kontakty" class="button is-alternate cta-section w-button">Cenová nabídka</a>
-      </div><div class="banner-cta-big_image-wrapper">
-        <img class="banner-cta-big-image left" src="a.webp" srcset="a.webp 500w" alt="Pylon">
-        <img class="banner-cta-big-image right w-dyn-bind-empty">
-      </div></section>
-      <section class="banner-cta-small w-condition-invisible"><h2>Nepoužitá varianta</h2></section>
+  <div data-banner-source class="banner-source" style="display:none"><div class="w-dyn-list"><div role="list" class="w-dyn-items">
+    <div role="listitem" class="w-dyn-item">
+      <div id="pylony-velky" class="banner-item">
+        <div class="banner-name">Pylony – velký</div>
+        <section data-banner-variant="velky" class="banner-cta-big"><div class="contain"><div class="banner-cta-big-columns">
+          <div class="banner-cta-big_content">
+            <h2 class="heading-style-h4">Pylony, které upoutají</h2>
+            <p>Přizpůsobíme pylon vašim potřebám.</p>
+            <a href="/kontakty" class="button is-alternate cta-section w-button">Cenová nabídka</a>
+          </div><div class="banner-cta-big_image-wrapper">
+            <img class="banner-cta-big-image left" src="a.webp" srcset="a.webp 500w" alt="Pylon">
+            <img class="banner-cta-big-image right w-dyn-bind-empty">
+          </div>
+        </div></div></section>
+        <section data-banner-variant="maly" class="banner-cta-small"><div class="contain"><div class="banner-cta-small_content">
+          <h2 class="heading-style-h4 cta-section">Pylony, které upoutají</h2>
+          <a href="/kontakty" class="button is-alternate cta-section w-button">Cenová nabídka</a>
+        </div></div></section>
+      </div>
     </div>
-    <div role="listitem" class="w-dyn-item" data-banner="rezana-grafika-maly" data-banner-name="Řezaná grafika – malý">
-      <section class="banner-cta-small"><h2 class="heading-style-h4 cta-section">Malý banner</h2></section>
+    <div role="listitem" class="w-dyn-item">
+      <div id="rezana-grafika-maly" class="banner-item">
+        <div class="banner-name">Řezaná grafika – malý</div>
+        <section data-banner-variant="velky" class="banner-cta-big w-condition-invisible"><h2>Vypnutá varianta</h2></section>
+        <section data-banner-variant="maly" class="banner-cta-small"><div class="contain"><div class="banner-cta-small_content">
+          <h2 class="heading-style-h4 cta-section">Malý banner</h2>
+          <a href="/kontakty" class="button is-alternate cta-section w-button">Cenová nabídka</a>
+        </div></div></section>
+      </div>
     </div>
   </div></div></div>`;
 
@@ -157,9 +173,14 @@ run('Bannery z CMS (zástupný text v rich textu)',
       rich[0].firstElementChild.tagName === 'P' && rich[0].children[1].classList.contains('banner-cta-big'));
     ok('prázdný odstavec po tokenu zmizel', rich[0].children.length === 2);
 
+    // Přepínač Velký banner je vypnutý → Webflow označí velkou variantu
+    // w-condition-invisible a do článku musí jít malá.
+    ok('vypnutá varianta se nevykreslí', !rich[1].querySelector('.banner-cta-big'));
+    ok('vybrala se malá varianta', rich[1].querySelectorAll('.banner-cta-small').length === 1);
+
     // Klient nemusí opisovat slug znak po znaku — název s diakritikou,
     // mezerami i pomlčkou musí vést na stejný záznam.
-    ok('název s diakritikou najde banner', rich[1].querySelectorAll('.banner-cta-small').length === 1);
+    ok('název s diakritikou najde banner', /Malý banner/.test(rich[1].textContent));
 
     // Token uprostřed věty: banner se vloží ZA odstavec, text zůstane.
     const veta = rich[1].querySelector('p');
@@ -171,22 +192,21 @@ run('Bannery z CMS (zástupný text v rich textu)',
     ok('žádný [banner…] nezůstal na stránce viditelný', !/\[banner/i.test(doc.body.textContent));
     ok('nenalezený banner i holé [banner] odstavec smazaly', rich[1].querySelectorAll('p').length === 2);
 
-    // Prázdné pole a vypnutá varianta nesmí skončit v článku.
+    // Do článku nesmí prosáknout pomocné prvky knihovny.
+    ok('skrytý nosič názvu se do článku nedostal', !doc.querySelector('.w-richtext .banner-name'));
+    ok('klon nenese data-banner-variant', !doc.querySelector('.w-richtext [data-banner-variant]'));
+    ok('klon nenese w-dyn-item ani role="listitem"', !doc.querySelector('.w-richtext [role="listitem"]'));
+
+    // Prázdné pole nesmí skončit v článku jako <img> bez src.
     const big = rich[0].querySelector('.banner-cta-big');
     ok('prázdné CMS pole (druhý obrázek) se nevykreslí', big.querySelectorAll('img').length === 1);
     ok('obrázek si nese srcset i alt', big.querySelector('img').getAttribute('srcset') === 'a.webp 500w' &&
       big.querySelector('img').getAttribute('alt') === 'Pylon');
-    ok('varianta vypnutá podmíněnou viditelností se nevykreslí',
-      !rich[0].querySelector('.banner-cta-small'));
-
-    // Klon nesmí táhnout do článku obal Webflow seznamu.
-    ok('klon nenese w-dyn-item ani role="listitem"',
-      !big.closest('.w-dyn-item') && !rich[0].querySelector('[role="listitem"]'));
 
     // Zdroj zůstává skrytý a nedotčený — vykresluje se z klonů.
     const src = doc.querySelector('[data-banner-source]');
     ok('zdroj zůstal skrytý', src.style.display === 'none');
-    ok('zdroj si nechal obě položky', src.querySelectorAll('[data-banner]').length === 2);
+    ok('zdroj si nechal obě položky', src.querySelectorAll('.banner-item').length === 2);
 
     // Bannery se vkládají v modulu 05, měření sedá v modulu 90 — tlačítko
     // banneru se tím poprvé vůbec dostane do GTM.

--- a/test/smoke.js
+++ b/test/smoke.js
@@ -121,64 +121,72 @@ run('Anglická mutace téže stránky (regrese detekce jazyka)',
   });
 
 // --- 4. bannery z CMS -----------------------------------------------------
-// Šablona článku vykreslí bannery do skrytého zdroje, v textu zůstane jen
-// zástupný odstavec. Fixture kopíruje skutečný výstup Webflow Collection
-// Listu včetně `w-dyn-bind-empty` na nevyplněném druhém obrázku.
+// Šablona vykreslí CELOU kolekci Bannery do skrytého zdroje (knihovna),
+// v kolekci Inspirace se nemění nic. Fixture kopíruje skutečný výstup Webflow
+// Collection Listu včetně `w-dyn-bind-empty` na nevyplněném druhém obrázku
+// a `w-condition-invisible` na struktuře, kterou vypnula podmíněná viditelnost.
 const BANNER_SOURCE = `
   <div data-banner-source style="display:none"><div class="w-dyn-list"><div role="list" class="w-dyn-items">
-    <div role="listitem" class="w-dyn-item" data-banner="pylony-velky">
+    <div role="listitem" class="w-dyn-item" data-banner="pylony-velky" data-banner-name="Pylony – velký">
       <section class="banner-cta-big"><div class="banner-cta-big_content">
         <h2 class="heading-style-h4">Pylony, které upoutají</h2>
         <a href="/kontakty" class="button is-alternate cta-section w-button">Cenová nabídka</a>
       </div><div class="banner-cta-big_image-wrapper">
-        <img class="banner-cta-big-image left" src="a.webp" alt="Pylon">
+        <img class="banner-cta-big-image left" src="a.webp" srcset="a.webp 500w" alt="Pylon">
         <img class="banner-cta-big-image right w-dyn-bind-empty">
       </div></section>
+      <section class="banner-cta-small w-condition-invisible"><h2>Nepoužitá varianta</h2></section>
     </div>
-    <div role="listitem" class="w-dyn-item" data-banner="pylony-maly">
+    <div role="listitem" class="w-dyn-item" data-banner="rezana-grafika-maly" data-banner-name="Řezaná grafika – malý">
       <section class="banner-cta-small"><h2 class="heading-style-h4 cta-section">Malý banner</h2></section>
-    </div>
-    <div role="listitem" class="w-dyn-item" data-banner="zapomenuty">
-      <section class="banner-cta-small"><h2 class="heading-style-h4 cta-section">Zapomenutý</h2></section>
     </div>
   </div></div></div>`;
 
 run('Bannery z CMS (zástupný text v rich textu)',
   `${BANNER_SOURCE}
    <div class="w-richtext"><p>Úvodní odstavec.</p><p>[banner:Pylony-Velky]</p></div>
-   <div class="w-richtext"><p>[banner]</p><p>[banner:neexistuje]</p><p>Závěr.</p></div>
-   <div data-banner-fallback></div>`,
+   <div class="w-richtext">
+     <p>Věta s <strong>tučným</strong> a <a href="/x">odkazem</a>. [banner: Řezaná grafika – malý ]</p>
+     <p>[banner:neexistuje]</p><p>[banner]</p><p>Závěr.</p>
+   </div>`,
   'https://www.eldr.cz/inspirace/jak-vybrat-reklamni-pylon',
   (win, doc) => {
     const rich = doc.querySelectorAll('.w-richtext');
     ok('pojmenovaný banner sedí v prvním rich textu', rich[0].querySelectorAll('.banner-cta-big').length === 1);
-    ok('název banneru je case-insensitive', !!rich[0].querySelector('.banner-cta-big'));
-    ok('holé [banner] vzalo další nepoužitý v pořadí', rich[1].querySelectorAll('.banner-cta-small').length === 1);
-    ok('banner je vložen PŘED zástupný odstavec, ne na konec',
+    ok('banner je vložen na místo tokenu, ne na konec',
       rich[0].firstElementChild.tagName === 'P' && rich[0].children[1].classList.contains('banner-cta-big'));
+    ok('prázdný odstavec po tokenu zmizel', rich[0].children.length === 2);
+
+    // Klient nemusí opisovat slug znak po znaku — název s diakritikou,
+    // mezerami i pomlčkou musí vést na stejný záznam.
+    ok('název s diakritikou najde banner', rich[1].querySelectorAll('.banner-cta-small').length === 1);
+
+    // Token uprostřed věty: banner se vloží ZA odstavec, text zůstane.
+    const veta = rich[1].querySelector('p');
+    ok('token uprostřed věty nechal text i formátování', /Věta s tučným a odkazem\./.test(veta.textContent.trim()));
+    ok('odkaz uvnitř odstavce přežil úklid tokenu', !!veta.querySelector('a[href="/x"]'));
+    ok('banner z tokenu uprostřed věty stojí za odstavcem',
+      veta.nextElementSibling.classList.contains('banner-cta-small'));
 
     ok('žádný [banner…] nezůstal na stránce viditelný', !/\[banner/i.test(doc.body.textContent));
-    ok('nenalezený banner odstavec smazal, ne vypsal', rich[1].querySelectorAll('p').length === 1);
+    ok('nenalezený banner i holé [banner] odstavec smazaly', rich[1].querySelectorAll('p').length === 2);
 
-    // Nevyplněný druhý obrázek nesmí skončit v článku jako <img> bez src.
+    // Prázdné pole a vypnutá varianta nesmí skončit v článku.
     const big = rich[0].querySelector('.banner-cta-big');
     ok('prázdné CMS pole (druhý obrázek) se nevykreslí', big.querySelectorAll('img').length === 1);
-    ok('vyplněný obrázek zůstal i s alt textem', big.querySelector('img').getAttribute('alt') === 'Pylon');
+    ok('obrázek si nese srcset i alt', big.querySelector('img').getAttribute('srcset') === 'a.webp 500w' &&
+      big.querySelector('img').getAttribute('alt') === 'Pylon');
+    ok('varianta vypnutá podmíněnou viditelností se nevykreslí',
+      !rich[0].querySelector('.banner-cta-small'));
 
     // Klon nesmí táhnout do článku obal Webflow seznamu.
     ok('klon nenese w-dyn-item ani role="listitem"',
       !big.closest('.w-dyn-item') && !rich[0].querySelector('[role="listitem"]'));
 
-    const fallback = doc.querySelector('[data-banner-fallback]');
-    ok('banner bez [banner:…] v textu spadl na náhradní místo',
-      fallback.querySelectorAll('.banner-cta-small').length === 1);
-    ok('náhradní místo dostalo právě ten zapomenutý',
-      /Zapomenutý/.test(fallback.textContent));
-
     // Zdroj zůstává skrytý a nedotčený — vykresluje se z klonů.
     const src = doc.querySelector('[data-banner-source]');
     ok('zdroj zůstal skrytý', src.style.display === 'none');
-    ok('zdroj si nechal všechny tři položky', src.querySelectorAll('[data-banner]').length === 3);
+    ok('zdroj si nechal obě položky', src.querySelectorAll('[data-banner]').length === 2);
 
     // Bannery se vkládají v modulu 05, měření sedá v modulu 90 — tlačítko
     // banneru se tím poprvé vůbec dostane do GTM.

--- a/test/smoke.js
+++ b/test/smoke.js
@@ -225,7 +225,42 @@ run('Článek bez zdroje bannerů (modul se musí vypnout)',
     ok('text článku zůstal nedotčený', doc.querySelector('.w-richtext p').textContent === '[banner:pylony-velky]');
   });
 
-// --- 5. prázdná stránka ---------------------------------------------------
+// --- 5. sdílení do AI ------------------------------------------------------
+// Hák je ve Webflow zapsaný jako DOM id, ne jako custom atribut. Modul se
+// na tom tiše vypínal a tlačítka zůstávala na href="#" — klik nedělal nic.
+const AI_LINKS = `
+  <a data-ai="chatgpt" href="#" class="button is-small is-custom">ChatGPT</a>
+  <a data-ai="googleai" href="#" class="button is-small is-custom">Google AI</a>
+  <a data-ai="perplexity" href="#" class="button is-small is-custom">Perplexity</a>
+  <a data-ai="claude" href="#" class="button is-small is-custom">Claude</a>`;
+
+const aiCheck = (win, doc) => {
+  const href = t => doc.querySelector(`[data-ai="${t}"]`).getAttribute('href');
+  ok('ChatGPT odkaz vyplněn', href('chatgpt').startsWith('https://chatgpt.com/?q='));
+  ok('Google AI odkaz vyplněn', href('googleai').includes('google.com/search'));
+  ok('Perplexity odkaz vyplněn', href('perplexity').startsWith('https://www.perplexity.ai/?q='));
+  ok('Claude odkaz vyplněn', href('claude').startsWith('https://claude.ai/new?q='));
+  ok('žádný odkaz nezůstal na #', !doc.querySelector('[data-ai][href="#"]'));
+  ok('odkazy se otevírají do nového okna', doc.querySelector('[data-ai]').getAttribute('target') === '_blank');
+};
+
+run('Sdílení do AI — hák jako DOM id (skutečný stav Webflow)',
+  `<div id="data-ai-share">${AI_LINKS}</div>`,
+  'https://www.eldr.cz/inspirace/jak-vybrat-reklamni-pylon', aiCheck);
+
+run('Sdílení do AI — hák jako custom atribut',
+  `<div data-ai-share>${AI_LINKS}</div>`,
+  'https://www.eldr.cz/inspirace/jak-vybrat-reklamni-pylon', aiCheck);
+
+run('Sdílení do AI — prompt v jazyce stránky',
+  `<div id="data-ai-share">${AI_LINKS}</div>`,
+  'https://www.eldr.cz/en/inspirace/jak-vybrat-reklamni-pylon',
+  (win, doc) => {
+    const q = decodeURIComponent(doc.querySelector('[data-ai="claude"]').getAttribute('href'));
+    ok('anglická mutace dostane anglický prompt', q.includes('Visit this URL'));
+  });
+
+// --- 6. prázdná stránka ---------------------------------------------------
 run('Prázdná stránka (moduly se musí samy vypnout)', '<div></div>', 'https://www.eldr.cz/404', () => {});
 
 console.log(`\n${pass} prošlo, ${fail} selhalo`);


### PR DESCRIPTION
Klient vkládal banner do článku jako escapovaný HTML v rich textu a Finsweet `attributes-richtext` ho na klientovi rozbalil. Prakticky tedy editoval kód.

## Co bylo na dosavadním stavu špatně

Ověřeno na živém `/inspirace/jak-vybrat-reklamni-pylon`:

- obrázek byl natvrdo opsaná CDN URL → **bez `srcset`**, do mobilu šla plná velikost, `alt` prázdný
- do každého článku se kopírovalo `id="w-node-_2a17c21a-…"`
- `fs-richtext-component="cta-small"` sedělo i na velkém banneru — překlep z kopírování
- Finsweet banner vykresloval až po `DOMContentLoaded`, takže **GTM na jeho tlačítko nikdy nesedlo**; kliky z bannerů se neměřily
- třídy bannerů neviděl audit tříd (byly v escapovaném HTML) — proto je první audit označil za sirotky, viz `_backup/FINDINGS.md`
- na `/en` i `/de` byly bannery česky — rich text se nikdy nelokalizoval (celý blog je zatím jen v češtině)

## Co dělá tenhle PR

Banner je záznam v CMS kolekci Bannery. Šablona článku vykreslí **celou kolekci** do skrytého zdroje `[data-banner-source]` ve správné Webflow struktuře (živé třídy, responzivní `srcset`, alt texty) — funguje tedy jako knihovna. Klient napíše do textu `[banner:Pylony – velký]` a modul to vymění za hotový banner.

**V kolekci Inspirace nepřibylo žádné pole.**

- adresuje se přes **Name i Slug** a klíč se normalizuje, takže `[banner:Pylony – velký]` i `[banner:pylony-velky]` najdou totéž
- token **nemusí být na samostatném řádku** — uklidí se po textových uzlech, takže odkazy a tučný text v odstavci zůstanou, a banner se vloží až za odstavec (`<section>` uvnitř `<p>` je neplatný HTML)
- token se z textu maže i při nenalezení — čtenář nikdy neuvidí holé `[banner:…]`, důvod jde do konzole
- prázdné CMS pole (`w-dyn-bind-empty`) i vypnutá varianta (`w-condition-invisible`) se z klonu zahazují

Modul je číslovaný **05**, hned za jádrem, a je to záměr: před `10-vars`, aby se do banneru doplnily tokeny `{#YOE#}`, a před `90-gtm`, aby na tlačítko banneru sedlo měření.

### Co si vynutilo Webflow Data API

API neumí navázat custom atribut na položce Collection Listu ani nastavit podmíněnou viditelnost podle Option pole. Proto:

- klíč jede přes **DOM id** (Slug) a **skrytý text `.banner-name`** (Name) místo `data-` atributů
- `Typ` (Velký/Malý) je **Switch „Velký banner"** — jediný typ pole, který jde navázat na viditelnost
- šablona vykreslí obě provedení označená `data-banner-variant`, Webflow to nepoužité označí `w-condition-invisible` a modul si vybere první, které projde

Pro klienta se tím nemění nic — pořád jen píše token a přepíná jeden checkbox.

## Změněné soubory

| Soubor | Co |
|---|---|
| `src/modules/05-banners.js` | nový modul |
| `test/smoke.js` | 20 nových kontrol nad fixture, která kopíruje skutečný výstup Webflow Collection Listu |
| `docs/bannery-cms.md` | datový model, kroky v Designeru, návod pro klienta, migrační mapa, lokalizace |
| `_backup/webflow/custom-code/*` | zálohy byly z 15. 8. a tvrdily, že patička jede na `v1.2.27`; přepsané živým stavem |
| `dist/eldr.js` | build |

`npm run check` — **48 prošlo, 0 selhalo**; lint bez chyb (6 warningů z `00-core.js` existovalo i předtím).

## Stav ve Webflow — hotovo, čeká na publish

- kolekce **Bannery** — 15 záznamů vytažených ze živého webu, obrázky napojené na stávající assety
- skrytý zdroj na šabloně `/inspirace/`, obě provedení navázaná na CMS
- **všech 8 článků přepsáno na tokeny**, ověřeno bajt po bajtu proti původnímu textu — 0 rozdílů, 0 zbylých embedů, 15 tokenů na místě
- site head i footer bumpnuté na `f0200cd`, bundle ověřený na jsDelivr
- šablona `Bannery Template` přepnutá na draft, ať nevzniknou veřejné `/bannery/…` stránky

**Zbývá publikovat web.** Do té doby na živém webu běží starý stav.

Po publikaci zkontrolovat: bannery na stejném místě jako dřív, konzole bez `[ELDR bannery]` hlášek, klik na tlačítko banneru pošle `button_click`.

Přejmenování tříd na client-first je až po publikaci — do té doby staré třídy drží vzhled starých publikovaných článků. Mapa je v `docs/bannery-cms.md`.