### PR TITLE
Sdílení do AI: doplněn Copilot a tlačítko pro zkopírování promptu

### DIFF
--- a/dist/eldr.js
+++ b/dist/eldr.js
@@ -1162,7 +1162,8 @@ function locale() {
     chatgpt:    function (q) { return 'https://chatgpt.com/?q=' + q; },
     googleai:   function (q) { return 'https://www.google.com/search?udm=50&aep=11&q=' + q; },
     perplexity: function (q) { return 'https://www.perplexity.ai/?q=' + q; },
-    claude:     function (q) { return 'https://claude.ai/new?q=' + q; }
+    claude:     function (q) { return 'https://claude.ai/new?q=' + q; },
+    copilot:    function (q) { return 'https://copilot.microsoft.com/?q=' + q; }
   };
 
   function copyPrompt() {
@@ -1192,12 +1193,22 @@ function locale() {
     if (text.indexOf('googleai') !== -1 || text.indexOf('gemini') !== -1) return 'googleai';
     if (text.indexOf('perplexity') !== -1) return 'perplexity';
     if (text.indexOf('claude') !== -1) return 'claude';
+    if (text.indexOf('copilot') !== -1) return 'copilot';
     return '';
   }
 
+  /* Tlačítko „Zkopírovat prompt" nevede nikam — jen strčí prompt do schránky.
+     Bez preventDefault by ho href="#" vyhodilo na začátek stránky. */
+  $$('a[data-ai="copy"]', scope).forEach(function (a) {
+    a.addEventListener('click', function (e) {
+      e.preventDefault();
+      copyPrompt();
+    });
+  });
+
   $$('a[href="#"], a[data-ai]', scope).forEach(function (a) {
     var key = serviceKey(a);
-    if (!key || !BUILD[key]) return;
+    if (key === 'copy' || !key || !BUILD[key]) return;
 
     a.href = BUILD[key](Q);
     a.target = '_blank';

--- a/src/modules/60-ai-share.js
+++ b/src/modules/60-ai-share.js
@@ -43,7 +43,8 @@
     chatgpt:    function (q) { return 'https://chatgpt.com/?q=' + q; },
     googleai:   function (q) { return 'https://www.google.com/search?udm=50&aep=11&q=' + q; },
     perplexity: function (q) { return 'https://www.perplexity.ai/?q=' + q; },
-    claude:     function (q) { return 'https://claude.ai/new?q=' + q; }
+    claude:     function (q) { return 'https://claude.ai/new?q=' + q; },
+    copilot:    function (q) { return 'https://copilot.microsoft.com/?q=' + q; }
   };
 
   function copyPrompt() {
@@ -73,12 +74,22 @@
     if (text.indexOf('googleai') !== -1 || text.indexOf('gemini') !== -1) return 'googleai';
     if (text.indexOf('perplexity') !== -1) return 'perplexity';
     if (text.indexOf('claude') !== -1) return 'claude';
+    if (text.indexOf('copilot') !== -1) return 'copilot';
     return '';
   }
 
+  /* Tlačítko „Zkopírovat prompt" nevede nikam — jen strčí prompt do schránky.
+     Bez preventDefault by ho href="#" vyhodilo na začátek stránky. */
+  $$('a[data-ai="copy"]', scope).forEach(function (a) {
+    a.addEventListener('click', function (e) {
+      e.preventDefault();
+      copyPrompt();
+    });
+  });
+
   $$('a[href="#"], a[data-ai]', scope).forEach(function (a) {
     var key = serviceKey(a);
-    if (!key || !BUILD[key]) return;
+    if (key === 'copy' || !key || !BUILD[key]) return;
 
     a.href = BUILD[key](Q);
     a.target = '_blank';

--- a/test/smoke.js
+++ b/test/smoke.js
@@ -232,7 +232,9 @@ const AI_LINKS = `
   <a data-ai="chatgpt" href="#" class="button is-small is-custom">ChatGPT</a>
   <a data-ai="googleai" href="#" class="button is-small is-custom">Google AI</a>
   <a data-ai="perplexity" href="#" class="button is-small is-custom">Perplexity</a>
-  <a data-ai="claude" href="#" class="button is-small is-custom">Claude</a>`;
+  <a data-ai="claude" href="#" class="button is-small is-custom">Claude</a>
+  <a data-ai="copilot" href="#" class="button is-small is-custom">Microsoft Copilot</a>
+  <a data-ai="copy" href="#" class="button is-small is-custom">Zkopírovat prompt</a>`;
 
 const aiCheck = (win, doc) => {
   const href = t => doc.querySelector(`[data-ai="${t}"]`).getAttribute('href');
@@ -240,7 +242,15 @@ const aiCheck = (win, doc) => {
   ok('Google AI odkaz vyplněn', href('googleai').includes('google.com/search'));
   ok('Perplexity odkaz vyplněn', href('perplexity').startsWith('https://www.perplexity.ai/?q='));
   ok('Claude odkaz vyplněn', href('claude').startsWith('https://claude.ai/new?q='));
-  ok('žádný odkaz nezůstal na #', !doc.querySelector('[data-ai][href="#"]'));
+  ok('Copilot odkaz vyplněn', href('copilot').startsWith('https://copilot.microsoft.com/?q='));
+  // „Zkopírovat prompt" nikam nevede — musí zůstat na # a klik nesmí skočit
+  // na začátek stránky, jinak čtenář přijde o pozici v článku.
+  ok('kopírovací tlačítko zůstalo na #', href('copy') === '#');
+  const ev = new win.Event('click', { bubbles: true, cancelable: true });
+  doc.querySelector('[data-ai="copy"]').dispatchEvent(ev);
+  ok('klik na kopírování nenaviguje (preventDefault)', ev.defaultPrevented);
+  ok('žádný odkaz na službu nezůstal na #',
+    !doc.querySelector('[data-ai][href="#"]:not([data-ai="copy"])'));
   ok('odkazy se otevírají do nového okna', doc.querySelector('[data-ai]').getAttribute('target') === '_blank');
 };
 


### PR DESCRIPTION
Po opravě háku `[data-ai-share]` začaly fungovat čtyři tlačítka ze šesti. Zbývající dvě modul neuměl obsloužit:

- **`data-ai="copilot"`** (Microsoft Copilot) nebyl vůbec v mapě služeb, takže mu nikdo nedoplnil `href`
- **`data-ai="copy"`** („Zkopírovat prompt") propadával stejnou podmínkou — zůstával na `href="#"`, takže klik jen vyskočil na začátek stránky místo zkopírování promptu

## Změna

- Copilot přibyl do mapy služeb (`https://copilot.microsoft.com/?q=…`) i do rozpoznávání podle textu
- kopírovací tlačítko má vlastní handler s `preventDefault` a ze smyčky pro služby se vyřazuje, aby mu nikdo nepřepsal `href`

## Testy

`npm run check` — **70 prošlo, 0 selhalo**. Nové kontroly hlídají, že Copilot dostane odkaz, že kopírovací tlačítko zůstane na `#`, že klik na něj nenaviguje, a že žádné tlačítko na službu nezůstane na `#`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WzaqAgrT6ACvm5wbmkfuTJ)_