### PR TITLE
Bannery: mezera nad a pod bannerem drží nezávisle na okolí

### DIFF
--- a/dist/eldr.css
+++ b/dist/eldr.css
@@ -174,3 +174,37 @@ body.lang-de .localization-show-only_de {
     transform: none;
   }
 }
+
+/* --- Bannery v článku: mezera nad a pod ----------------------------------
+   Odsazení samotného banneru je ve Webflow na třídě `.banner-cta-big`
+   i `.banner-cta-small` (margin 64 px nahoře i dole). Sem patří jen to,
+   co style panel zapsat neumí — vztah mezi sourozenci v rich textu.
+
+   Proč to je potřeba: odsazení v článku nedrží margin, ale padding
+   odstavců a nadpisů (`p { padding-bottom: 19px }`, `h2 { padding-top:
+   1.5em }`). Padding se nesčítá do collapsingu, takže mezera kolem banneru
+   vycházela pokaždé jinak podle toho, co kolem něj náhodou stálo:
+
+     odstavec → banner    19 + 64 = 83 px
+     banner → nadpis      64 + 72 = 136 px
+     banner → odstavec    64 + 0  = 64 px
+
+   Klient by to musel dorovnávat prázdnými řádky, a i to by se rozjelo,
+   jakmile někdo výš v článku něco přepíše. Sousedům se proto odsazení
+   směrem k banneru vynuluje a platí jen margin banneru: 64 px nad i pod,
+   ať je kolem cokoliv.
+
+   Hookové třídy `eldr-banner` a `eldr-banner-before` přidává při vkládání
+   modul 05-banners.js — banner v článku vzniká až v prohlížeči, takže
+   ve Webflow na tenhle prvek nejde ve style panelu sáhnout. Dvě sousední
+   sekce banneru se navzájem nevynulují, mezi nimi zůstane 64 px. */
+
+.w-richtext > .eldr-banner-before {
+  margin-bottom: 0;
+  padding-bottom: 0;
+}
+
+.w-richtext > .eldr-banner + *:not(.eldr-banner) {
+  margin-top: 0;
+  padding-top: 0;
+}

--- a/dist/eldr.js
+++ b/dist/eldr.js
@@ -142,6 +142,10 @@ function locale() {
                               nemusel hlídat slug a mohl napsat „Pylony – velký"
      [data-banner-variant]    velký / malý provedení uvnitř položky
 
+   Vložený banner dostane hookovou třídu `eldr-banner` a jeho předchůdce
+   v článku `eldr-banner-before`. Na ně visí jediné dvě pravidla v
+   src/eldr.css, která srovnávají mezeru kolem banneru — viz komentář tam.
+
    Proč id a skrytý text místo data atributů: Webflow Data API neumí na
    položce Collection Listu navázat custom atribut na CMS pole. Navázat jde
    DOM id a text, takže klíče jedou přes ně. Stejný důvod má i výběr varianty
@@ -161,6 +165,8 @@ function locale() {
   var NAME = '.banner-name';
   var VARIANT = '[data-banner-variant]';
   var RICH = '.w-richtext';
+  var BANNER = 'eldr-banner';
+  var BEFORE = 'eldr-banner-before';
   var BLOCKS = 'p, li, blockquote, h1, h2, h3, h4, h5, h6';
 
   /* `[banner:nazev]`. Mezery kolem dvojtečky se odpouštějí, diakritika
@@ -205,6 +211,7 @@ function locale() {
 
     var clone = chosen.cloneNode(true);
     clone.removeAttribute('data-banner-variant');
+    clone.classList.add(BANNER);
     $$('.w-condition-invisible, .w-dyn-bind-empty', clone).forEach(function (el) {
       if (el.parentNode) el.parentNode.removeChild(el);
     });
@@ -212,6 +219,23 @@ function locale() {
     var frag = document.createDocumentFragment();
     frag.appendChild(clone);
     return frag;
+  }
+
+  /* Prázdný odstavec — klient odentroval navíc, nebo mu po smazání tokenu
+     zbyl `<p><br></p>`. Vedle banneru by dělal mezeru navíc, tak jde pryč.
+     Obrázek ani vložené video se za prázdné nepovažují. */
+  function isBlank(el) {
+    if (/\S/.test((el.textContent || '').replace(/\u00a0/g, ' '))) return false;
+    return !el.querySelector('img, figure, iframe, video, svg, hr');
+  }
+
+  function dropBlanks(el, next) {
+    while (el && el.nodeType === 1 && isBlank(el)) {
+      var sibling = next ? el.nextElementSibling : el.previousElementSibling;
+      el.parentNode.removeChild(el);
+      el = sibling;
+    }
+    return el;
   }
 
   var library = {};
@@ -239,7 +263,7 @@ function locale() {
     });
   }
 
-  function process(block) {
+  function process(block, rich) {
     var text = block.textContent || '';
     if (text.indexOf('[') === -1) return;
 
@@ -270,24 +294,52 @@ function locale() {
     stripTokens(block);
 
     /* Banner smí být sourozenec odstavce, ne jeho obsah — <section> uvnitř
-       <p> je neplatný HTML a prohlížeč by ho z odstavce stejně vystrčil. */
+       <p> je neplatný HTML a prohlížeč by ho z odstavce stejně vystrčil.
+
+       Vkládá se až za prvek, který je přímým potomkem rich textu. Když token
+       stojí v odrážce, banner tím pádem vyjde za celý seznam, ne doprostřed
+       něj — a hlavně je vždycky na stejné úrovni, takže na něj sedí pravidla
+       pro mezeru z src/eldr.css. */
     var anchor = block;
+    while (anchor.parentNode && anchor.parentNode !== rich) anchor = anchor.parentNode;
+    if (!anchor.parentNode) return;
+
+    var firstBanner = null;
+    var lastBanner = null;
+
     frags.forEach(function (frag) {
       var last = frag.lastChild;
       anchor.parentNode.insertBefore(frag, anchor.nextSibling);
       anchor = last;
+      lastBanner = last;
+      if (!firstBanner) firstBanner = last;
     });
 
     /* Odstavec, ve kterém byl jen token, po úklidu zůstal prázdný. */
     if (!block.textContent.trim() && !block.children.length && block.parentNode) {
-      block.parentNode.removeChild(block);
+      var wrapper = block.parentNode;
+      wrapper.removeChild(block);
+      /* Odrážka s tokenem byla v seznamu sama — prázdný <ul> by v článku
+         zůstal jako neviditelná mezera. */
+      if (wrapper !== rich && !wrapper.children.length && wrapper.parentNode) {
+        wrapper.parentNode.removeChild(wrapper);
+      }
     }
+
+    if (!firstBanner) return;
+
+    /* Prázdné odstavce těsně kolem banneru pryč, ať klient nemusí hlídat,
+       kolikrát odentroval. Označit souseda jde až potom — musí to být ten,
+       co u banneru doopravdy zůstal. */
+    dropBlanks(lastBanner.nextElementSibling, true);
+    var before = dropBlanks(firstBanner.previousElementSibling, false);
+    if (before && !before.classList.contains(BANNER)) before.classList.add(BEFORE);
   }
 
   onReady(function () {
     $$(RICH).forEach(function (rich) {
       if (source.contains(rich)) return;
-      $$(BLOCKS, rich).forEach(process);
+      $$(BLOCKS, rich).forEach(function (block) { process(block, rich); });
     });
   });
 })();

--- a/docs/bannery-cms.md
+++ b/docs/bannery-cms.md
@@ -130,6 +130,33 @@ odeber. Nepřepisuj styly ručně, rozjede se to.
 třídách, aby vzhled seděl 1:1. Přejmenovat je jde teprve až bude nový systém
 odpublikovaný a ověřený — do té doby drží vzhled i staré publikované články.
 
+### Mezera nad a pod bannerem
+
+Odsazení banneru je **ve Webflow na třídách** `banner-cta-big`
+a `banner-cta-small`: `margin-top` i `margin-bottom` 64 px. Chceš-li ho
+změnit, měň ho tam, ne v kódu.
+
+V kódu je jen to, co style panel zapsat neumí — vynulování odsazení
+u sousedů. V rich textu totiž mezery nedrží margin, ale padding odstavců
+a nadpisů (`p { padding-bottom: 19px }`, `h2 { padding-top: 1.5em }`),
+a padding se do margin collapsingu nepočítá. Mezera kolem banneru proto
+vycházela pokaždé jinak podle toho, co kolem něj náhodou stálo:
+
+| sousedi | před opravou | po opravě |
+|---|---|---|
+| odstavec → banner | 83 px | 64 px |
+| banner → nadpis | 136 px | 64 px |
+| banner → odstavec | 0 px (text se lepil na pruh) | 64 px |
+
+Modul `05-banners.js` proto při vkládání označí banner třídou `eldr-banner`
+a jeho předchůdce třídou `eldr-banner-before`; na ty visí dvě pravidla
+v `src/eldr.css`. Zároveň zahodí prázdné odstavce těsně kolem banneru,
+takže klient nemusí hlídat, kolikrát odentroval. Dva bannery za sebou se
+nevynulují — mezi nimi zůstane 64 px.
+
+Token v odrážce vloží banner **až za celý seznam**, ne doprostřed něj —
+banner musí být přímý potomek rich textu, jinak na něj pravidla nesednou.
+
 ### Na co si dát pozor
 
 - **Nepoužívej u obrázků grid child positioning.** Webflow z něj generuje
@@ -183,6 +210,11 @@ prohlížeče.
 
 **Ve Webflow Editoru banner neuvidíš** — tam zůstane jen `[banner:…]`.
 Zobrazí se až v náhledu publikovaného webu.
+
+**Odentrovávat nemusíš.** Dopiš odstavec, enter, napiš token, enter, piš dál.
+Kolem banneru vyjde 64 px nad i pod, ať za ním stojí nadpis, odstavec nebo
+odrážky. Prázdné řádky kolem tokenu se zahodí, takže když jich tam pár
+zůstane, na vzhledu se to neprojeví.
 
 ## Migrace stávajících článků
 

--- a/src/eldr.css
+++ b/src/eldr.css
@@ -174,3 +174,37 @@ body.lang-de .localization-show-only_de {
     transform: none;
   }
 }
+
+/* --- Bannery v článku: mezera nad a pod ----------------------------------
+   Odsazení samotného banneru je ve Webflow na třídě `.banner-cta-big`
+   i `.banner-cta-small` (margin 64 px nahoře i dole). Sem patří jen to,
+   co style panel zapsat neumí — vztah mezi sourozenci v rich textu.
+
+   Proč to je potřeba: odsazení v článku nedrží margin, ale padding
+   odstavců a nadpisů (`p { padding-bottom: 19px }`, `h2 { padding-top:
+   1.5em }`). Padding se nesčítá do collapsingu, takže mezera kolem banneru
+   vycházela pokaždé jinak podle toho, co kolem něj náhodou stálo:
+
+     odstavec → banner    19 + 64 = 83 px
+     banner → nadpis      64 + 72 = 136 px
+     banner → odstavec    64 + 0  = 64 px
+
+   Klient by to musel dorovnávat prázdnými řádky, a i to by se rozjelo,
+   jakmile někdo výš v článku něco přepíše. Sousedům se proto odsazení
+   směrem k banneru vynuluje a platí jen margin banneru: 64 px nad i pod,
+   ať je kolem cokoliv.
+
+   Hookové třídy `eldr-banner` a `eldr-banner-before` přidává při vkládání
+   modul 05-banners.js — banner v článku vzniká až v prohlížeči, takže
+   ve Webflow na tenhle prvek nejde ve style panelu sáhnout. Dvě sousední
+   sekce banneru se navzájem nevynulují, mezi nimi zůstane 64 px. */
+
+.w-richtext > .eldr-banner-before {
+  margin-bottom: 0;
+  padding-bottom: 0;
+}
+
+.w-richtext > .eldr-banner + *:not(.eldr-banner) {
+  margin-top: 0;
+  padding-top: 0;
+}

--- a/src/modules/05-banners.js
+++ b/src/modules/05-banners.js
@@ -20,6 +20,10 @@
                               nemusel hlídat slug a mohl napsat „Pylony – velký"
      [data-banner-variant]    velký / malý provedení uvnitř položky
 
+   Vložený banner dostane hookovou třídu `eldr-banner` a jeho předchůdce
+   v článku `eldr-banner-before`. Na ně visí jediné dvě pravidla v
+   src/eldr.css, která srovnávají mezeru kolem banneru — viz komentář tam.
+
    Proč id a skrytý text místo data atributů: Webflow Data API neumí na
    položce Collection Listu navázat custom atribut na CMS pole. Navázat jde
    DOM id a text, takže klíče jedou přes ně. Stejný důvod má i výběr varianty
@@ -39,6 +43,8 @@
   var NAME = '.banner-name';
   var VARIANT = '[data-banner-variant]';
   var RICH = '.w-richtext';
+  var BANNER = 'eldr-banner';
+  var BEFORE = 'eldr-banner-before';
   var BLOCKS = 'p, li, blockquote, h1, h2, h3, h4, h5, h6';
 
   /* `[banner:nazev]`. Mezery kolem dvojtečky se odpouštějí, diakritika
@@ -83,6 +89,7 @@
 
     var clone = chosen.cloneNode(true);
     clone.removeAttribute('data-banner-variant');
+    clone.classList.add(BANNER);
     $$('.w-condition-invisible, .w-dyn-bind-empty', clone).forEach(function (el) {
       if (el.parentNode) el.parentNode.removeChild(el);
     });
@@ -90,6 +97,23 @@
     var frag = document.createDocumentFragment();
     frag.appendChild(clone);
     return frag;
+  }
+
+  /* Prázdný odstavec — klient odentroval navíc, nebo mu po smazání tokenu
+     zbyl `<p><br></p>`. Vedle banneru by dělal mezeru navíc, tak jde pryč.
+     Obrázek ani vložené video se za prázdné nepovažují. */
+  function isBlank(el) {
+    if (/\S/.test((el.textContent || '').replace(/\u00a0/g, ' '))) return false;
+    return !el.querySelector('img, figure, iframe, video, svg, hr');
+  }
+
+  function dropBlanks(el, next) {
+    while (el && el.nodeType === 1 && isBlank(el)) {
+      var sibling = next ? el.nextElementSibling : el.previousElementSibling;
+      el.parentNode.removeChild(el);
+      el = sibling;
+    }
+    return el;
   }
 
   var library = {};
@@ -117,7 +141,7 @@
     });
   }
 
-  function process(block) {
+  function process(block, rich) {
     var text = block.textContent || '';
     if (text.indexOf('[') === -1) return;
 
@@ -148,24 +172,52 @@
     stripTokens(block);
 
     /* Banner smí být sourozenec odstavce, ne jeho obsah — <section> uvnitř
-       <p> je neplatný HTML a prohlížeč by ho z odstavce stejně vystrčil. */
+       <p> je neplatný HTML a prohlížeč by ho z odstavce stejně vystrčil.
+
+       Vkládá se až za prvek, který je přímým potomkem rich textu. Když token
+       stojí v odrážce, banner tím pádem vyjde za celý seznam, ne doprostřed
+       něj — a hlavně je vždycky na stejné úrovni, takže na něj sedí pravidla
+       pro mezeru z src/eldr.css. */
     var anchor = block;
+    while (anchor.parentNode && anchor.parentNode !== rich) anchor = anchor.parentNode;
+    if (!anchor.parentNode) return;
+
+    var firstBanner = null;
+    var lastBanner = null;
+
     frags.forEach(function (frag) {
       var last = frag.lastChild;
       anchor.parentNode.insertBefore(frag, anchor.nextSibling);
       anchor = last;
+      lastBanner = last;
+      if (!firstBanner) firstBanner = last;
     });
 
     /* Odstavec, ve kterém byl jen token, po úklidu zůstal prázdný. */
     if (!block.textContent.trim() && !block.children.length && block.parentNode) {
-      block.parentNode.removeChild(block);
+      var wrapper = block.parentNode;
+      wrapper.removeChild(block);
+      /* Odrážka s tokenem byla v seznamu sama — prázdný <ul> by v článku
+         zůstal jako neviditelná mezera. */
+      if (wrapper !== rich && !wrapper.children.length && wrapper.parentNode) {
+        wrapper.parentNode.removeChild(wrapper);
+      }
     }
+
+    if (!firstBanner) return;
+
+    /* Prázdné odstavce těsně kolem banneru pryč, ať klient nemusí hlídat,
+       kolikrát odentroval. Označit souseda jde až potom — musí to být ten,
+       co u banneru doopravdy zůstal. */
+    dropBlanks(lastBanner.nextElementSibling, true);
+    var before = dropBlanks(firstBanner.previousElementSibling, false);
+    if (before && !before.classList.contains(BANNER)) before.classList.add(BEFORE);
   }
 
   onReady(function () {
     $$(RICH).forEach(function (rich) {
       if (source.contains(rich)) return;
-      $$(BLOCKS, rich).forEach(process);
+      $$(BLOCKS, rich).forEach(function (block) { process(block, rich); });
     });
   });
 })();

--- a/test/smoke.js
+++ b/test/smoke.js
@@ -173,6 +173,13 @@ run('Bannery z CMS (zástupný text v rich textu)',
       rich[0].firstElementChild.tagName === 'P' && rich[0].children[1].classList.contains('banner-cta-big'));
     ok('prázdný odstavec po tokenu zmizel', rich[0].children.length === 2);
 
+    // Hooky pro mezeru kolem banneru: odsazení sousedů se vypíná v CSS,
+    // protože v rich textu ho drží padding odstavců a nadpisů.
+    ok('vložený banner nese hook eldr-banner',
+      rich[0].children[1].classList.contains('eldr-banner'));
+    ok('předchůdce banneru nese hook eldr-banner-before',
+      rich[0].firstElementChild.classList.contains('eldr-banner-before'));
+
     // Přepínač Velký banner je vypnutý → Webflow označí velkou variantu
     // w-condition-invisible a do článku musí jít malá.
     ok('vypnutá varianta se nevykreslí', !rich[1].querySelector('.banner-cta-big'));
@@ -214,6 +221,53 @@ run('Bannery z CMS (zástupný text v rich textu)',
     big.querySelector('.button').click();
     const ev = win.dataLayer.filter(e => e.event === 'button_click');
     ok('GTM měří tlačítko vloženého banneru', ev.length === 1 && ev[0].button_text === 'Cenová nabídka');
+  });
+
+// Mezera kolem banneru musí vyjít stejně, ať klient odentruje jakkoliv:
+// prázdné odstavce kolem banneru jdou pryč a soused se označí hookem.
+// Token v odrážce nesmí banner vrazit doprostřed seznamu — musel by pak
+// sedět o úroveň níž a pravidlo pro mezeru by na něj nesedlo.
+run('Bannery: mezera drží bez ohledu na odentrování',
+  `${BANNER_SOURCE}
+   <div class="w-richtext">
+     <p>Odstavec.</p><p>&nbsp;</p><p><br></p><p>[banner:pylony-velky]</p><p><br></p><p>&nbsp;</p><p>Pokračování.</p>
+   </div>
+   <div class="w-richtext">
+     <ul><li>[banner:rezana-grafika-maly]</li></ul><p>Za seznamem.</p>
+   </div>
+   <div class="w-richtext">
+     <p>Před.</p><p>[banner:pylony-velky] [banner:rezana-grafika-maly]</p><p>Po.</p>
+   </div>`,
+  'https://www.eldr.cz/inspirace/jak-vybrat-reklamni-pylon',
+  (win, doc) => {
+    const rich = doc.querySelectorAll('.w-richtext');
+
+    const kids = rich[0].children;
+    ok('prázdné odstavce kolem banneru zmizely', kids.length === 3);
+    ok('pořadí zůstalo odstavec → banner → odstavec',
+      kids[0].textContent.trim() === 'Odstavec.' &&
+      kids[1].classList.contains('banner-cta-big') &&
+      kids[2].textContent.trim() === 'Pokračování.');
+    ok('hook sedí na odstavci, který u banneru doopravdy zůstal',
+      kids[0].classList.contains('eldr-banner-before') &&
+      kids[1].classList.contains('eldr-banner'));
+
+    // Token v odrážce: banner patří za celý seznam, ne mezi <li>.
+    ok('banner z odrážky je přímý potomek rich textu',
+      rich[1].firstElementChild.classList.contains('banner-cta-small'));
+    ok('prázdný seznam po vyjmutí odrážky zmizel', !rich[1].querySelector('ul'));
+    ok('text za seznamem zůstal', rich[1].children.length === 2 &&
+      rich[1].children[1].textContent.trim() === 'Za seznamem.');
+
+    // Dva bannery za sebou se nesmí navzájem přilepit — hook `before`
+    // dostane jen odstavec před prvním z nich.
+    const dva = rich[2].children;
+    ok('dva tokeny v odstavci daly dva bannery za sebou', dva.length === 4 &&
+      dva[1].classList.contains('eldr-banner') && dva[2].classList.contains('eldr-banner'));
+    ok('banner před bannerem se nevynuluje', !dva[1].classList.contains('eldr-banner-before'));
+    ok('hook dostal jen odstavec před prvním bannerem',
+      dva[0].classList.contains('eldr-banner-before') &&
+      !dva[3].classList.contains('eldr-banner-before'));
   });
 
 run('Článek bez zdroje bannerů (modul se musí vypnout)',


### PR DESCRIPTION
## Co bylo špatně

V rich textu nedrží odsazení `margin`, ale `padding` odstavců a nadpisů
(`p { padding-bottom: 19px }`, `h2 { padding-top: 1.5em }`). Padding se
do margin collapsingu nepočítá, takže mezera kolem banneru vycházela
pokaždé jinak podle toho, co kolem něj náhodou stálo:

| sousedi | před | po |
|---|---|---|
| odstavec → banner | 83 px | 64 px |
| banner → nadpis | 136 px | 64 px |
| banner → odstavec | 0 px (text se lepil na červený pruh) | 64 px |

Klient by to musel dorovnávat prázdnými řádky — a i to by se rozjelo,
jakmile by někdo výš v článku něco přepsal.

## Co se změnilo

**Ve Webflow** (mimo tenhle diff): `banner-cta-big` i `banner-cta-small`
dostaly `margin-bottom: 64px`, aby seděl s existujícím `margin-top: 64px`.
Odsazení banneru tak zůstává na třídě v Designeru, jak má.

**V kódu** jen to, co style panel zapsat neumí — vztah mezi sourozenci
v rich textu:

- `05-banners.js` označí vložený banner třídou `eldr-banner` a jeho
  předchůdce třídou `eldr-banner-before`
- `src/eldr.css` těmhle sousedům odsazení směrem k banneru vynuluje,
  takže platí jen margin banneru
- dva bannery za sebou se nevynulují — mezi nimi zůstane 64 px

Navíc dvě věci k univerzálnosti:

- prázdné odstavce těsně kolem banneru se zahodí, takže na vzhledu
  nezáleží, kolikrát klient odentroval
- token v odrážce vloží banner **až za celý seznam**; banner tak vždycky
  vyjde jako přímý potomek rich textu, jinak by na něj pravidla nesedla
  (prázdný seznam po vyjmutí odrážky jde pryč)

## Ověření

Změřeno v Chromiu na offline kopii živého článku
`/inspirace/jak-vybrat-reklamni-pylon` (skutečné HTML + publikované
Webflow CSS + nový bundle): **64 px nad i pod** u malého i velkého
provedení, na 1440 px i na 390 px, před nadpisem i před odstavcem,
s prázdnými odstavci kolem tokenu i bez nich. Konzole bez hlášek
`[ELDR bannery]`.

Smoke test rozšířen na **82 assertions** (z 70), všechny procházejí.
Lint bez chyb.

## Zbývá po mergi

Přepnout site head i footer na nový commit a publikovat — bez publikace
se změna třídy ve Webflow ani nový bundle na web nedostanou.

## Mimo scope, k rozhodnutí

`.banner-cta-small` má na tabletu/mobilu `padding-top: 2rem` a
`padding-bottom: 3rem` — nesymetrický padding **uvnitř** červeného pruhu.
Vypadá to jako překlep z Designeru, ale je to vzhled uvnitř banneru,
ne mezera kolem něj, tak jsem na to nesahal.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WzaqAgrT6ACvm5wbmkfuTJ)_