### PR TITLE
Záloha custom kódu: web připnutý na 0b12f9b

### DIFF
--- a/_backup/webflow/custom-code/_MANIFEST.md
+++ b/_backup/webflow/custom-code/_MANIFEST.md
@@ -1,11 +1,13 @@
 # Záloha custom kódu — Webflow ELDR
 Site ID: 635940ec249b210e8902edd4 · Workspace: 63593aa9923e4a3417813ca5
-Pořízeno: 2026-08-27 · Stav webu: publikováno 2026-08-17
+Pořízeno: 2026-08-27 · Stav webu: publikováno 2026-08-27, bundle připnutý
+na commit `0b12f9b` (head i footer).
 
-⚠️ Tahle záloha se ROZEŠLA s realitou (byla z 15. 8., live mezitím přešel
-na sloučený bundle). Kdo se na ni spolehne, udělá špatné rozhodnutí —
-před prací se site head/footer si vždycky vytáhni aktuální stav přes
-`data_scripts_tool > get_site_freeform_code` a tenhle soubor přepiš.
+⚠️ Záloha stárne rychle. Než sáhneš na site head/footer, **vždycky si
+vytáhni aktuální stav** přes `data_scripts_tool > get_site_freeform_code`
+a tenhle soubor přepiš — 27. 8. tvrdila, že live jede na `v1.2.27`,
+zatímco už dávno běžel sloučený bundle. A při zápisu posílej **celý obsah
+pole**, nikdy „jen tenhle blok" (incident 2026-08-15, viz FINDINGS.md).
 
 | Soubor | Umístění ve Webflow |
 |---|---|

--- a/_backup/webflow/custom-code/site-footer.html
+++ b/_backup/webflow/custom-code/site-footer.html
@@ -7,7 +7,7 @@
 <!-- End Swiper JS Library -->
 
 <!-- Webkit Studio Code -->
-<script defer src="https://cdn.jsdelivr.net/gh/lukas-webkit-studio/eldr@9176337/dist/eldr.min.js"></script>
+<script defer src="https://cdn.jsdelivr.net/gh/lukas-webkit-studio/eldr@0b12f9b/dist/eldr.min.js"></script>
 <!-- End Webkit Studio Code -->
 
 <!-- Lead Script -->

--- a/_backup/webflow/custom-code/site-head.html
+++ b/_backup/webflow/custom-code/site-head.html
@@ -29,5 +29,5 @@
 <!-- End [Attributes by Finsweet] -->
 
 <!-- Webkit Studio Code -->
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/lukas-webkit-studio/eldr@9176337/dist/eldr.min.css" />
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/lukas-webkit-studio/eldr@0b12f9b/dist/eldr.min.css" />
 <!-- End Webkit Studio Code -->


### PR DESCRIPTION
Doběh po mergi #6 a publikaci webu.

Site head i footer jsou ve Webflow připnuté na commit `0b12f9b`
(merge #6). Záloha v repu to teď odpovídá — ověřeno řádek po řádku proti
`get_site_freeform_code`, obojí shodné.

Manifest už netvrdí, že je záloha zastaralá. Místo varování drží pravidlo,
jak s ní zacházet: před zápisem si vytáhnout aktuální stav přes API
a posílat vždy celý obsah pole, nikdy „jen tenhle blok" (incident
2026-08-15).

Bez změny kódu — jen `_backup/`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WzaqAgrT6ACvm5wbmkfuTJ)_