### PR TITLE
docs: mapa produktových stránek Figma → Webflow

### DIFF
--- a/docs/nocni-beh-prompt.md
+++ b/docs/nocni-beh-prompt.md
@@ -1,0 +1,46 @@
+# Prompt pro noční Routine
+
+Routine se musí založit **z claude.ai** (Routines → nová), ne odsud —
+z API se ke spouštěné session nedají připojit konektory, takže by běžela
+bez Webflow a Figmy a nic by nesvedla.
+
+**Nastavení:** opakování každou hodinu přes noc, konektory **Webflow
+(Elektro Drapač)** a **Figma**, repozitář `lukas-webkit-studio/eldr`,
+větev `claude/figma-webflow-7-pages-ffqfoo`.
+
+---
+
+Pokračuj v přestavbě produktových stránek ELDR ve Webflow podle návrhu z Figmy. Běžíš autonomně v noci, uživatel spí a výsledek chce najít ráno hotový. Nečekej na odpovědi, rozhoduj sám.
+
+## Nejdřív si načti kontext
+
+V repozitáři `lukas-webkit-studio/eldr`, větev `claude/figma-webflow-7-pages-ffqfoo`, přečti v tomto pořadí:
+
+1. `CLAUDE.md` — pravidla projektu
+2. `docs/produktove-stranky-stav.md` — stav série, rozhodnutí zadavatele, co zbývá
+3. `docs/produktove-stranky-figma.md` — mapa Figma framů na stránky, kostra stránky, ověřený postup, technické limity
+
+Ty dokumenty jsou úplné. Neodvozuj nic z paměti, drž se jich.
+
+## Co dělat
+
+Vezmi první stránku, která v tabulce stavu není hotová, a postav ji celou: struktura podle návrhu, texty, kotvy sekcí, přepnutí galerie na správný produkt, obrázky nahrané a zatříděné do assetů. Pak další stránku. Pokračuj, dokud nedojdou.
+
+Po **každé dokončené stránce**:
+
+- doplň řádek v tabulce stavu v `docs/produktove-stranky-stav.md`
+- doplň úkony pro člověka do sekce „Co člověk udělá ráno" — plná cesta k assetu i místo ve stránce, ať ráno nikdo nic nedohledává
+- zapiš rozhodnutí, která jsi udělal za pochodu
+- commitni a pushni na větev
+
+Commituj průběžně, ne až na konci. Když session spadne, práce nesmí zmizet.
+
+## Co nedělat
+
+- **Nepublikuj web.** Ani na konci. Publikace je rozhodnutí uživatele.
+- Nesahej na komponentu `Navbar_2024-12`, dokud nejsou hotové všechny stránky — je společná pro celý web.
+- Nezakládej nové CSS třídy, když existuje použitelná.
+
+## Až bude hotovo
+
+Zkontroluj, že seznam pro člověka je úplný a srozumitelný, a skonči.

--- a/docs/produktove-stranky-figma.md
+++ b/docs/produktove-stranky-figma.md
@@ -56,7 +56,7 @@ vidět — tam patří `true`.
 |---|---|---|---|---|---|
 | `1676:3577` | 3D nápisy, loga a jednotlivá písmena | `67cd93a208e0807c31816af3` | — | 6 | hotovo (vzor) |
 | `1676:2328` | Reklamní pylony a totemy | `64022ba739ac3bd5ed6820d4` | 2 | 2 | hotovo (vzor) |
-| `1921:2203` | Orientační systémy | `6401fcf4e07002bda0fea1d5` | 0 | 0 | |
+| `1921:2203` | Orientační systémy | `6401fcf4e07002bda0fea1d5` | 0 | 0 | **postaveno** (draft `orientacni-systemy-new`) |
 | `1886:2143` | Výstrče, lékárenské znaky | `64634aa422af13a00b2303c6` | 3 | 2 | neshoda |
 | `1926:2736` | Zámečnické konstrukce, plexisklo | `640e42ac69533920507f0278` | 2 | 2 | |
 | `1929:3364` | Velkoformátový tisk | `640e43b5aa58d3423e64cb87` | 4 | 3 | neshoda |
@@ -128,6 +128,68 @@ Pořadí je pořadí v menu, ne abecední.
    `(old) 3D nápisy, loga a jednotlivá písmena`.
 6. Publikace až po odsouhlasení — publish pouští ven i cizí rozdělanou
    práci, viz CLAUDE.md.
+
+**Do doplnění překladů se nepublikuje.** Rozhodnutím z 3. 9. se překlady
+řeší až po dokončení všech českých verzí. Do té doby by prohození slugů
+poslalo na `/en/` a `/de/` prázdné stránky, takže publish musí počkat na
+obojí — hotové české verze i doplněné EN a DE.
+
+## Galerie: filtr jde přepnout přes API
+
+Galerie **není** collection list typu `CMSCollection` — hledat ho tak nic
+nenajde. Jsou to dva elementy typu `DynamoWrapper`:
+
+| Styl | Co to je |
+|---|---|
+| `swiper ImageSlider__Collection` | hlavní pás náhledů |
+| `swiper-popup PopUpSlider__Collection` | galerie po rozkliknutí |
+
+Oba mají vlastní filtr a **oba se musí přepnout**, jinak náhledy ukazují
+jeden produkt a popup jiný.
+
+Filtr se čte `data_element_settings_tool > get_settings` s
+`type: "query_settings"` a prázdným dotazem — pod `value_type: "filter"` ho
+nenajdeš, vrací se jako `collectionListSetting` pod klíčem `filters`.
+Zapisuje se `set_settings` s klíčem `filters` a `static_json`:
+
+```json
+[{"fieldSlug":"produkt-2","operator":"equals","value":"<id možnosti>"}]
+```
+
+Kolekce je Fotografie `646d5c52aab44e9fcf5974b8`, pole `produkt-2`
+(Fotogalerie). ID možností vrátí `data_cms_tool > get_collection_details`.
+Řazení (`poradi` sestupně) a limit 30 se nechávají být.
+
+Takže „galerie nechat jak jsou" znamená jen přepnout tenhle jeden filtr —
+nic se nepředělává.
+
+## Obrázky z Figmy: pozor na náhledy
+
+`download_assets` vrací zdrojové bitmapy, ale v návrhu jsou **od každého
+motivu dvě verze — originál a zmenšený náhled**. U Orientačních systémů to
+bylo 2288×1712 vedle 286×214 téhož obrázku. Brát je podle pořadí znamená
+poslat na web náhled. Vždy změřit rozměry a vzít větší z dvojice.
+
+Než se něco nahrává, stojí za to zkontrolovat, jestli fotka na webu už
+není: hero obrázek Orientačních systémů byl v assetech
+(`68b4a6efa70ab6fafae027c7`) v produkční kvalitě a stačilo ho přiřadit.
+
+Produktový obrázek má **tři jazykové sloty** — combo třídy
+`localization-show-only_cs` / `_en` / `_de`, přepínané naším CSS v
+`src/eldr.css` podle třídy `lang-*` na `<body>` (modul `20-locale.js`).
+U grafiky s textem tam patří tři různé soubory. U reálné fotky bez textu
+se do všech tří dá tentýž asset — jinak by EN a DE verze zůstaly
+u obrázku předchozího produktu.
+
+## Co API u textů umí
+
+`set_text` funguje i na `String` uzly uvnitř `Strong`, ne jen na
+Heading/Paragraph — takže tučné úseky se dají přepsat bez rozbití
+formátování. Když je tučný úsek na jiném místě než v předloze, přesune se
+`move_element`; přebytečné fragmenty se mažou `remove_element`.
+
+DOM id sekce se **nenastavuje** přes `set_attributes` (skončí interní
+chybou) — patří na to `data_element_settings_tool > set_dom_id`.
 
 ## Čtení velkého Figma souboru
 

--- a/docs/produktove-stranky-figma.md
+++ b/docs/produktove-stranky-figma.md
@@ -123,16 +123,30 @@ Pořadí je pořadí v menu, ne abecední.
 2. Naplnit obsahem podle Figma framu, sekcí po sekci.
 3. Galerie se nepředělávají — jen se zařadí pod správnou `section_product`.
 4. Ověřit na preview.
-5. Prohodit slugy: stará stránka `…-old` + draft, nová na ostrý slug. URL
-   i SEO zůstanou, stará verze slouží jako záloha. Stejně jako
+5. Rozpracovaná stránka žije v **`/dev/`** — složka `672a93ee45bdc8fc69626c95`,
+   výsledná adresa `eldr.cz/dev/<slug>`. **Není to draft.** Draft je jen pro
+   to, co nikdo nechce; rozdělaná práce se naopak publikuje, aby šla
+   prohlédnout, ale **bez indexování**.
+6. Prohodit slugy až nakonec: stará stránka `…-old`, nová na ostrý slug.
+   URL i SEO zůstanou, stará verze slouží jako záloha. Stejně jako
    `(old) 3D nápisy, loga a jednotlivá písmena`.
-6. Publikace až po odsouhlasení — publish pouští ven i cizí rozdělanou
+7. Publikace až po odsouhlasení — publish pouští ven i cizí rozdělanou
    práci, viz CLAUDE.md.
 
-**Do doplnění překladů se nepublikuje.** Rozhodnutím z 3. 9. se překlady
-řeší až po dokončení všech českých verzí. Do té doby by prohození slugů
-poslalo na `/en/` a `/de/` prázdné stránky, takže publish musí počkat na
-obojí — hotové české verze i doplněné EN a DE.
+### Bez indexování
+
+`data_sitemap_tool > update_page_sitemap_status` s `includeInSitemap:
+false` vyřadí stránku ze sitemap.xml. To je vše, co API umí.
+
+**Samotné `/dev/` chráněné není.** robots.txt zakazuje jen `/admin/`
+a dev stránky nemají `noindex` — dosud je chránilo jen to, že byly draft.
+Jakmile se publikují, jsou indexovatelné. Systémové řešení je přidat
+`Disallow: /dev/` do robots.txt (Site settings → SEO); API na robots.txt
+nesahá, musí se to naklikat.
+
+**Do doplnění překladů se neprohazují slugy.** Rozhodnutím z 3. 9. se
+překlady řeší až po dokončení všech českých verzí; do té doby by ostrá
+adresa poslala na `/en/` a `/de/` prázdné stránky. V `/dev/` to nevadí.
 
 ## Galerie: filtr jde přepnout přes API
 
@@ -163,6 +177,34 @@ Kolekce je Fotografie `646d5c52aab44e9fcf5974b8`, pole `produkt-2`
 Takže „galerie nechat jak jsou" znamená jen přepnout tenhle jeden filtr —
 nic se nepředělává.
 
+## Galerie: designér fotky neořezával
+
+Ověřeno porovnáním otisků obrázků z návrhu proti všem fotkám galerie.
+Čtyři fotky, které návrh staví dopředu, jsou **bajt po bajtu tytéž
+soubory**, co už v kolekci jsou — stejné rozměry, vzdálenost otisku 0.
+Designér je jen dal na jiné pozice.
+
+Co vypadá jako jiný ořez, dělá slider sám: náhledy mají pevný poměr
+a `object-fit` ořízne každou fotku podle jejího tvaru. V návrhu má
+designér rámečky jednoho poměru, takže výsledek vypadá jinak.
+
+**Přeuspořádání je proto jedno volání** `update_collection_items` s novými
+hodnotami `poradi` — žádné stahování, ořezávání ani nahrávání. Stačí dát
+vybraným fotkám hodnotu nad dosavadní maximum (u Orientačních systémů
+2100/2080/2060/2040 nad původní 2000).
+
+Jak najít, které fotky designér vybral, bez ručního porovnávání:
+
+1. `download_assets` na produktovou sekci vrátí zdrojové bitmapy z návrhu.
+2. URL všech fotek galerie se vytáhnou z živé stránky (`src` v HTML),
+   ne přes API — je to levnější a pořadí odpovídá řazení podle `poradi`.
+3. Spárovat perceptuálním otiskem (16×16 průměrový hash, vzdálenost ≤ 8).
+   Pozice v seznamu → `poradi` → ID položky.
+
+Jediný obrázek, který designér **opravdu** ořízl, byla produktová fotka
+v pravém sloupci (1440×2560 → 1406×1406) — ta se bere z návrhu, ne z
+galerie.
+
 ## Obrázky z Figmy: pozor na náhledy
 
 `download_assets` vrací zdrojové bitmapy, ale v návrhu jsou **od každého
@@ -180,6 +222,19 @@ Produktový obrázek má **tři jazykové sloty** — combo třídy
 U grafiky s textem tam patří tři různé soubory. U reálné fotky bez textu
 se do všech tří dá tentýž asset — jinak by EN a DE verze zůstaly
 u obrázku předchozího produktu.
+
+## Vzhled: co se dědí špatně
+
+Chyby, které vznikly duplikací vzoru a našly se až vizuálním porovnáním
+s návrhem. U dalších stránek zkontrolovat rovnou:
+
+| Co | Projev | Oprava |
+|---|---|---|
+| výřez hero fotky | ukazuje jinou část snímku než návrh | combo třída `image-focus-*` na `header_product_background-image`; existují `-top` (50% 3%), `-pylon` (100% 0%), `-ppp` (50% 20%), `-vystrce` (50% 50%) |
+| produktová fotka bez šikmé hrany | obdélník místo zkoseného rámečku | combo `clipped` na `product_image-wrapper` — nese `clip-path` |
+| zděděná combo třída podle jiné stránky | `product_image._3d-napisy` — prázdná, jen mate | odstranit ze `style_names` |
+| první štítek bez ikony | ve vzoru ji nemá, návrh ano | doplnit `DivBlock.header_product_metatag-icon` > `HtmlEmbed.icon-embed-xsmall` před textový blok |
+| ikony v `section_layout253` | zděděné z 3D nápisů (štětec, štít) | přepsat `code` v `HtmlEmbed`; ikony jsou inline SVG s `currentColor` |
 
 ## Co API u textů umí
 

--- a/docs/produktove-stranky-figma.md
+++ b/docs/produktove-stranky-figma.md
@@ -103,6 +103,19 @@ Pořadí je pořadí v menu, ne abecední.
    světelné reklamy?", kdežto na pylonech je to lokální kopie. Pro údržbu
    je lepší komponenta — na nových stránkách použít ji.
 
+4. **Web běží ve třech jazycích a překlady jsou vyplněné.** Locales:
+   `cs` primární (`66052b1245cd8094542338a7`), `en`
+   (`66052b1245cd8094542338a5`), `de` (`66052b1245cd8094542338a6`).
+   Ověřeno na živém webu — `/en/produkty/orientacni-systemy` má vlastní
+   title i H1 („Orientation systems"), není to fallback na češtinu.
+
+   Nová stránka vzniklá duplikací má **prázdné EN a DE**. Překlady jdou
+   dopsat přes `data_localization_tool > update_static_content` (píše jen
+   do sekundárních locale, primární je read-only), ale texty se musí
+   nejdřív vytáhnout ze staré stránky přes `get_page_content` s
+   `localeId`. U textů, které návrh mění, překlad neexistuje a musí
+   vzniknout nový — to platí bez ohledu na zvolený postup.
+
 ## Postup přestavby jedné stránky
 
 1. `create_page` s `duplicateOf` vzorové stránky → dostane se client-first

--- a/docs/produktove-stranky-figma.md
+++ b/docs/produktove-stranky-figma.md
@@ -24,19 +24,31 @@ page-wrapper
 ├─ Cookies Consent, GTM, Global Styles, Navbar_2024-12   (komponenty)
 ├─ main-wrapper
 │  ├─ header.section_header_product.text-color-white      hero
-│  ├─ section.section_layout400                           úvodní blok
-│  ├─ section.section_cards                               karty = kotvy sekcí
+│  ├─ section.section_layout400                           karty = rozcestník na sekce
+│  ├─ (section.section_cards.hide)                        MRTVÁ, nekopírovat
+│  ├─ (section.section_layout253)                         nadpis + dva textové sloupce
 │  ├─ N× section.section_product  #<id z menu>            produkt + galerie
-│  ├─ (volitelně section_showreel / section_layout253)
-│  ├─ Jak probíhá výroba světelné reklamy?                (komponenta)
-│  ├─ Důvěřují nám přední české i zahraniční firmy        (komponenta)
-│  └─ Záruka prvotřídní kvality  (prop Viditelnost CTA = false)
+│  ├─ (section.section_showreel)
+│  ├─ section.section_layout121-2 #jak-probiha-vyroba     Jak probíhá výroba
+│  ├─ 3× section.section_process-link                     kroky procesu
+│  ├─ section.section_layout188 #duvera                   Důvěřují nám
+│  └─ layout298_component                                 Záruka prvotřídní kvality
 └─ Footer_2024-12
 ```
 
-`section_cards` je na 3D nápisech skrytá třídou `hide`, ale v návrhu je
-živá na všech stránkách — je to blok „Podívejte se blíže na to, co vás
-zajímá" a jeho karty odpovídají 1:1 kotvám v menu.
+Ověřeno na živém HTML obou hotových stránek, ne odhadem z Designeru.
+
+**`section_layout400` je ten rozcestník** — blok „Podívejte se blíže na to,
+co vás zajímá / Prozkoumejte pestrou škálu profilů" a jeho karty odpovídají
+1:1 kotvám v menu. Nezaměňovat se `section_cards`, což je starší skrytý
+duplikát téhož obsahu; ten na nové stránky nepatří.
+
+Stránka s jedinou produktovou sekcí `section_layout400` nemá — rozcestník
+na jednu položku nedává smysl (viz Orientační systémy).
+
+Komponenta „Záruka prvotřídní kvality" má prop **Viditelnost CTA**. Na 3D
+nápisech i pylonech je `false`, v návrhu Orientačních systémů je CTA pruh
+vidět — tam patří `true`.
 
 ## Párování framů
 
@@ -85,9 +97,11 @@ Pořadí je pořadí v menu, ne abecední.
    `section_showreel#totemy` mají stejné id. Nevalidní HTML, kotva
    `#totemy` skočí jen na první. Nekopírovat dál.
 
-3. **`section_layout121 2` na pylonech** je Webflow duplikát třídy
-   (mezera a číslo v názvu) místo komponenty „Jak probíhá výroba světelné
-   reklamy?". Na nových stránkách použít komponentu.
+3. **`section_layout121 2` je duplikát třídy** (mezera a číslo v názvu,
+   v CSS `section_layout121-2`). Renderují ji obě hotové stránky stejně,
+   ale na 3D nápisech je zabalená v komponentě „Jak probíhá výroba
+   světelné reklamy?", kdežto na pylonech je to lokální kopie. Pro údržbu
+   je lepší komponenta — na nových stránkách použít ji.
 
 ## Postup přestavby jedné stránky
 

--- a/docs/produktove-stranky-figma.md
+++ b/docs/produktove-stranky-figma.md
@@ -1,0 +1,111 @@
+# Produktové stránky: Figma → Webflow
+
+Mapa pro přestavbu produktových stránek podle Figma návrhu. Zjištěno
+čtením Figma API a živého webu, ne odhadem.
+
+## Zdroje
+
+- **Figma:** `TYIPfNxhM7scK7QG6OCGGs` („ELDR Pracovný"), sekce `1676:3011`
+  („Produkty"). Framy uvnitř nejsou pojmenované — párování níž.
+- **Webflow site:** `635940ec249b210e8902edd4` (ELDR)
+- **Kotvy sekcí:** ground truth je menu na živém webu, ne Figma. Vytáhne se:
+
+  ```
+  curl -s https://www.eldr.cz/produkty/3d-napisy-loga-a-jednotliva-pismena \
+    | grep -oE 'href="/produkty/[^"]*#[^"]*"' | sed 's/href="//; s/"$//' | awk '!seen[$0]++'
+  ```
+
+## Kostra produktové stránky
+
+Ověřeno na obou hotových stránkách (3D nápisy, Pylony a totemy):
+
+```
+page-wrapper
+├─ Cookies Consent, GTM, Global Styles, Navbar_2024-12   (komponenty)
+├─ main-wrapper
+│  ├─ header.section_header_product.text-color-white      hero
+│  ├─ section.section_layout400                           úvodní blok
+│  ├─ section.section_cards                               karty = kotvy sekcí
+│  ├─ N× section.section_product  #<id z menu>            produkt + galerie
+│  ├─ (volitelně section_showreel / section_layout253)
+│  ├─ Jak probíhá výroba světelné reklamy?                (komponenta)
+│  ├─ Důvěřují nám přední české i zahraniční firmy        (komponenta)
+│  └─ Záruka prvotřídní kvality  (prop Viditelnost CTA = false)
+└─ Footer_2024-12
+```
+
+`section_cards` je na 3D nápisech skrytá třídou `hide`, ale v návrhu je
+živá na všech stránkách — je to blok „Podívejte se blíže na to, co vás
+zajímá" a jeho karty odpovídají 1:1 kotvám v menu.
+
+## Párování framů
+
+| Figma node | Stránka | Webflow pageId | Karet | Kotev | Stav |
+|---|---|---|---|---|---|
+| `1676:3577` | 3D nápisy, loga a jednotlivá písmena | `67cd93a208e0807c31816af3` | — | 6 | hotovo (vzor) |
+| `1676:2328` | Reklamní pylony a totemy | `64022ba739ac3bd5ed6820d4` | 2 | 2 | hotovo (vzor) |
+| `1921:2203` | Orientační systémy | `6401fcf4e07002bda0fea1d5` | 0 | 0 | |
+| `1886:2143` | Výstrče, lékárenské znaky | `64634aa422af13a00b2303c6` | 3 | 2 | neshoda |
+| `1926:2736` | Zámečnické konstrukce, plexisklo | `640e42ac69533920507f0278` | 2 | 2 | |
+| `1929:3364` | Velkoformátový tisk | `640e43b5aa58d3423e64cb87` | 4 | 3 | neshoda |
+| `1953:2003` | Vstupní portály a architektonické prvky | `640220c81cee12c964d37bdc` | 3 | 3 | |
+| `1958:2631` | Prvky podpory prodeje | `6402284b510487502b852799` | 3 | 3 | |
+| `1438:6615` | Světelné panely a tabule | `6401fe511792a68d1d2aee58` | 4 | 4 | |
+| `2179:2707` | Designová a interiérová svítidla | `6402252f78f3f12a5bb17234` | 7 | 7 | největší |
+| `2112:2583` | — prázdný frame, jen podklad | — | — | — | ignorovat |
+
+Frame `1078:1354` (320 × 10917) je mobilní verze, ne samostatná stránka.
+
+## Kotvy podle stránek
+
+Pořadí je pořadí v menu, ne abecední.
+
+| Stránka | id sekcí |
+|---|---|
+| 3D nápisy | `profil-1`, `profil-9`, `profil-4`, `profil-5s`, `profil-8`, `profil-3` |
+| Světelné panely a tabule | `svetelne-panely`, `intarzie`, `reklamni-tabule`, `menuboardy` |
+| Pylony a totemy | `pylony`, `totemy` |
+| Výstrče | `vystrce`, `lekarenske-znaky` (+ chybí *Atypické výstrče*) |
+| Zámečnické konstrukce | `zamecnicke-konstrukce`, `opracovani-a-prodej-plexiskla` |
+| Velkoformátový tisk | `uvod`, `rezana-grafika`, `dalsi-druhy-polepu` (+ chybí *Designové obrazy*) |
+| Vstupní portály | `vstupni-portaly`, `architektonicke-prvky`, `vlajky` |
+| Designová svítidla | `designova-svitidla`, `zarovkove-svetelne-napisy`, `neonove-napisy`, `mechove-steny`, `reklama-z-cortenoveho-plechu`, `svetelna-cisla-domu`, `stojaci-lampy` |
+| Prvky podpory prodeje | `prvky-podpory-prodeje`, `led-displaye`, `led-obrazovky` |
+| Orientační systémy | žádné — stránka má jednu produktovou sekci |
+
+## Otevřené věci
+
+1. **Návrh má víc sekcí než menu.** Výstrče mají v návrhu *Atypické
+   výstrče*, velkoformátový tisk *Designové obrazy*. Nové sekce dostanou
+   id `atypicke-vystrce` a `designove-obrazy`. Doplnění odkazů do menu je
+   zásah do komponenty `Navbar_2024-12`, tedy do všech stránek naráz —
+   řešit až budou stránky hotové, samostatně.
+
+2. **Duplicitní DOM id na pylonech.** `section_product#totemy` i
+   `section_showreel#totemy` mají stejné id. Nevalidní HTML, kotva
+   `#totemy` skočí jen na první. Nekopírovat dál.
+
+3. **`section_layout121 2` na pylonech** je Webflow duplikát třídy
+   (mezera a číslo v názvu) místo komponenty „Jak probíhá výroba světelné
+   reklamy?". Na nových stránkách použít komponentu.
+
+## Postup přestavby jedné stránky
+
+1. `create_page` s `duplicateOf` vzorové stránky → dostane se client-first
+   struktura i Relume bloky bez zakládání nových tříd.
+2. Naplnit obsahem podle Figma framu, sekcí po sekci.
+3. Galerie se nepředělávají — jen se zařadí pod správnou `section_product`.
+4. Ověřit na preview.
+5. Prohodit slugy: stará stránka `…-old` + draft, nová na ostrý slug. URL
+   i SEO zůstanou, stará verze slouží jako záloha. Stejně jako
+   `(old) 3D nápisy, loga a jednotlivá písmena`.
+6. Publikace až po odsouhlasení — publish pouští ven i cizí rozdělanou
+   práci, viz CLAUDE.md.
+
+## Čtení velkého Figma souboru
+
+`get_metadata` na celou sekci Produkty vrací ~730 KB a do kontextu se
+nevejde. Harness ho uloží do souboru — grepovat, ne číst celý.
+Identifikace framů: jména vrstev nesou názvy produktů, screenshot horních
+~1100 px framu stačí na potvrzení. `get_design_context` volat na
+jednotlivé sekce, nikdy na celý frame.

--- a/docs/produktove-stranky-figma.md
+++ b/docs/produktove-stranky-figma.md
@@ -56,7 +56,7 @@ vidět — tam patří `true`.
 |---|---|---|---|---|---|
 | `1676:3577` | 3D nápisy, loga a jednotlivá písmena | `67cd93a208e0807c31816af3` | — | 6 | hotovo (vzor) |
 | `1676:2328` | Reklamní pylony a totemy | `64022ba739ac3bd5ed6820d4` | 2 | 2 | hotovo (vzor) |
-| `1921:2203` | Orientační systémy | `6401fcf4e07002bda0fea1d5` | 0 | 0 | **postaveno** (draft `orientacni-systemy-new`) |
+| `1921:2203` | Orientační systémy | `6401fcf4e07002bda0fea1d5` | 0 | 0 | **hotovo**, publikováno na `/dev/orientacni-systemy` |
 | `1886:2143` | Výstrče, lékárenské znaky | `64634aa422af13a00b2303c6` | 3 | 2 | neshoda |
 | `1926:2736` | Zámečnické konstrukce, plexisklo | `640e42ac69533920507f0278` | 2 | 2 | |
 | `1929:3364` | Velkoformátový tisk | `640e43b5aa58d3423e64cb87` | 4 | 3 | neshoda |

--- a/docs/produktove-stranky-figma.md
+++ b/docs/produktove-stranky-figma.md
@@ -205,6 +205,40 @@ Jediný obrázek, který designér **opravdu** ořízl, byla produktová fotka
 v pravém sloupci (1440×2560 → 1406×1406) — ta se bere z návrhu, ne z
 galerie.
 
+## Známý limit: výměna obrázku přes API rozbije `sizes`
+
+**Toto je nejzávažnější omezení celého postupu.** Když se obrázku změní
+asset nebo třídy přes API, Webflow nepřepočítá atribut `sizes` a zapíše
+mobilní default. Prohlížeč pak ze `srcset` vybere 500px variantu
+a roztáhne ji přes celou šířku — výsledek je viditelně rozmazaný.
+
+| | `sizes` |
+|---|---|
+| stránka upravená v Designeru | `(max-width: 2288px) 100vw, 2288px` |
+| tentýž obrázek po výměně přes API | `(max-width: 479px) 100vw, 343px` |
+
+Zdrojový soubor i `srcset` jsou přitom totožné — liší se jen tahle
+nápověda pro prohlížeč.
+
+**Opravit se to přes API nedá.** Ověřeno třemi cestami:
+
+- `data_element_tool > set_attributes` → interní chyba
+- `data_element_settings_tool > set_settings` s klíčem `attributes` →
+  `"sizes" is a reserved attribute name`
+- nastavení assetu přes `set_settings` místo `set_image_asset` → `sizes`
+  zůstává rozbité
+
+Postiženy jsou přesně ty obrázky, kterých se API dotklo; ostatní na téže
+stránce mají `sizes` v pořádku.
+
+**Jediná oprava je v Designeru:** otevřít stránku, vybrat obrázek a znovu
+mu přiřadit asset (stačí ho vybrat v panelu). Webflow `sizes` přepočítá
+podle skutečné šířky prvku. Pak publikovat.
+
+Praktický důsledek pro zbylé stránky: buď se počítá s ručním průchodem
+obrázků v Designeru po každé stránce, nebo se obrázky přes API vůbec
+nevyměňují a nechají se na Designer.
+
 ## Obrázky z Figmy: pozor na náhledy
 
 `download_assets` vrací zdrojové bitmapy, ale v návrhu jsou **od každého

--- a/docs/produktove-stranky-figma.md
+++ b/docs/produktove-stranky-figma.md
@@ -231,13 +231,40 @@ nápověda pro prohlížeč.
 Postiženy jsou přesně ty obrázky, kterých se API dotklo; ostatní na téže
 stránce mají `sizes` v pořádku.
 
-**Jediná oprava je v Designeru:** otevřít stránku, vybrat obrázek a znovu
-mu přiřadit asset (stačí ho vybrat v panelu). Webflow `sizes` přepočítá
-podle skutečné šířky prvku. Pak publikovat.
+**Jediná oprava je v Designeru:** vybrat obrázek a znovu mu přiřadit
+asset. Webflow `sizes` přepočítá podle skutečné šířky prvku.
 
-Praktický důsledek pro zbylé stránky: buď se počítá s ručním průchodem
-obrázků v Designeru po každé stránce, nebo se obrázky přes API vůbec
-nevyměňují a nechají se na Designer.
+### Dělba práce, která z toho plyne
+
+Protože klikání v Designeru je jediná cesta, rozdělí se práce takhle:
+
+| Kdo | Co |
+|---|---|
+| tenhle repozitář / agent | stáhne obrázky z návrhu, ověří rozlišení (pozor na náhledy), nahraje je do assetů, zatřídí do složek, pojmenuje a doplní alt text |
+| člověk v Designeru | u každého obrázku na stránce vybere ten správný z asset panelu — tím se `sizes` opraví — a publikuje |
+
+Agent obrázek do stránky **může** vložit rovnou; slouží pak jako
+zástupný, aby bylo vidět, co kam patří, a člověk ho jen překlikne.
+
+### Konvence složek v assetech
+
+```
+Produkty/                        6a99a9b55edcfaff2b6b0d82
+  Orientační systémy/            6a99a9ba4dfafeff4a964328
+    hero.webp
+    orientacni-systemy-budov-a-arealu.png
+  <další produkt>/
+    hero.webp
+    <název sekce>.png
+```
+
+Jedna podsložka na produktovou stránku, uvnitř `hero` a pak soubory
+pojmenované podle sekce, do které patří. Alt text se plní rovnou při
+nahrání — je to jediné místo, kde ho lze zapsat přes API bez zásahu do
+stránky.
+
+Pozor: **asset folder nejde přes API smazat.** Zakládat jen složky, které
+opravdu budou potřeba.
 
 ## Obrázky z Figmy: pozor na náhledy
 

--- a/docs/produktove-stranky-id-mapa.md
+++ b/docs/produktove-stranky-id-mapa.md
@@ -1,0 +1,158 @@
+# ID mapa duplikátu 3D nápisů
+
+Každá stránka vzniklá `create_page` s `duplicateOf:
+67cd93a208e0807c31816af3` (3D nápisy) má **stejná element ID** jako
+předloha. Ověřeno na dvou nezávislých duplikátech (Zámečnické konstrukce,
+Výstrče) — ID sedí do posledního znaku.
+
+Díky tomu se nemusí strom stránky pokaždé prohledávat. `query_elements`
+navíc pod kapotou volá `/v2/assets` a **naráží na 429** už po pár
+voláních za sebou; mutace (`set_text`, `remove_element`, `set_style`,
+`set_dom_id`, `set_settings`) tenhle limit nemají. Čtení tedy šetři,
+zapisuj v dávkách.
+
+`component` v `element_id` je vždy **ID stránky**, ne komponenty.
+
+## Bloky stránky
+
+| Blok | element |
+|---|---|
+| hero `header.section_header_product` | `51b75afb-8535-285d-4c5e-7c5259fe971c` |
+| rozcestník `section_layout400` | `4986df31-c5f9-6b15-742d-6a42b1e51ad2` |
+| mrtvá `section_cards.hide` (mazat) | `f3a2c0d7-5578-6f7e-a147-46f81af1c6db` |
+| `section_layout253` | `12d758e8-b4c1-5e3d-1d60-e1f93db77e8c` |
+
+### Hero
+
+| Co | element |
+|---|---|
+| H1 (String) | `51b75afb-8535-285d-4c5e-7c5259fe9724` |
+| podnadpis, 1. část | `51b75afb-8535-285d-4c5e-7c5259fe9726` |
+| podnadpis, tučný úsek | `e15e5cf4-ac1a-00a8-e2d2-327abca8b3b9` |
+| podnadpis, tečka | `e15e5cf4-ac1a-00a8-e2d2-327abca8b3ba` |
+| štítek „Životnost desítky let" (String / kořen) | `1b5c8eb8-…cae0771` / `1b5c8eb8-0204-46bc-6be3-b7115cae076d` |
+| štítek „Úsporné LED" | `ca8e8997-5af3-28a0-b066-99709db0fdcf` |
+| štítek „Odborná montáž" | `4750f8c4-983f-faeb-c315-0e6e2a2344e9` |
+| štítek „Kompletní servis" | `65805fe8-16f7-c9c2-c284-f7bd48a0c597` |
+
+### Rozcestník
+
+Uvozující věta: `4986df31-c5f9-6b15-742d-6a42b1e51adb`
+
+| Karta | kořen (Link) | nadpis | popis | obrázek |
+|---|---|---|---|---|
+| 1 | `4986df31-…e51ade` | `…e51ae6` | `…e51ae9` | `…e51ae0` |
+| 2 | `4986df31-…e51aea` | `…e51af3` | `…e51af6` | `…e51aec` |
+| 3 | `4986df31-…e51af7` | `…e51b00` | `…e51b03` | `…e51af9` |
+| 4 | `4986df31-…e51b04` | `…e51b0d` | `…e51b10` | |
+| 5 | `1527740d-462a-eead-ca84-a49a4e8303a1` | `…8303aa` | `…8303ad` | |
+| 6 | `55e431b2-09db-2e82-2fed-b46c4835a920` | `…4835a929` | `…4835a92c` | |
+
+Prefix karet 1–4 je `4986df31-c5f9-6b15-742d-6a42b1e51`. Karty odkazují
+`linkType: pageSection` na produktové sekce 1–6 ve stejném pořadí, takže
+po smazání nadbytečných sekcí i karet zbytek sedí sám.
+
+### `section_layout253`
+
+Levý sloupec: nadpis `12d758e8-…77e98`, odstavec `…77e9a`, text tlačítka
+`…77e9e`.
+
+| Položka vpravo | nadpis | textové fragmenty (v pořadí) |
+|---|---|---|
+| 1 | `12d758e8-…77eaa` | `cd4f0604-ac87-a429-3db0-2b6c33015bbb`, `12d758e8-…77eac`, `b8c2d867-90b5-ef81-9bf2-d654e28441fe`, **`f88c3212-8702-f7b7-f3df-6ddc84232286`**, `f88c3212-…232287` |
+| 2 | `12d758e8-…77eb3` | `12d758e8-…77eb5`, **`9b11c60b-ca0e-9cf7-5803-e2060b7e538a`**, `d4e2b012-576d-bbed-34ad-43c27ed4e1d8`, `0ef5a156-461a-2998-e502-004ef3a8e94c`, **`f6ccb7db-8cb1-6f71-e1d4-4357c518be32`**, `f6ccb7db-…518be33` |
+
+Tučně = `Strong`.
+
+## Produktové sekce
+
+| # | id v předloze | element sekce |
+|---|---|---|
+| 1 | `profil-1` | `3b1868e6-f203-9b85-0f6f-e9fb15f06b1c` |
+| 2 | `profil-3` | `cd2d0122-db01-458c-4f72-f9ec68809c07` |
+| 3 | `profil-4` | `c9352813-4932-9bb7-94f1-70852d627444` |
+| 4 | `profil-5s` | `20712323-2bf7-cd83-0598-56b1fc74cf5c` |
+| 5 | `profil-8` | `a6b052bc-f10e-22fa-4bc6-ecc7537fcc42` |
+| 6 | `profil-9` | `658e272e-f2a3-ec63-87f5-44cecf18e701` |
+
+### Vnitřek sekcí 1–3
+
+Sekce má tři „metatag" štítky; návrh má dva a **oba s ikonou**. Vzor
+z hotové stránky: nechat štítky 2 a 3, druhému přidat combo
+`margin-right margin-xxsmall` (`set_style` na `["product_metatag-link",
+"margin-right","margin-xxsmall"]`) a **smazat štítek 1** (ten jediný
+ikonu nemá). Levnější než ikonu dostavovat.
+
+| Co | sekce 1 | sekce 2 | sekce 3 |
+|---|---|---|---|
+| štítek 1 (kořen, mazat) | `39d70114-…179ec1` | `cd2d0122-…809c11` | `c9352813-…62744e` |
+| štítek 2 kořen / text | `…179ec4` / `…179ec8` | `…809c14` / `…809c18` | `…627451` / `…627455` |
+| štítek 3 kořen / text | `…179ec9` / `…179ecd` | `…809c19` / `…809c1d` | `…627456` / `…62745a` |
+| H2 | `3b1868e6-…f06b28` | `cd2d0122-…809c20` | `c9352813-…62745d` |
+| úvodní odstavec | `4ac62fd0-491f-79d8-3fd1-21b03f03d0f1` | `cd2d0122-…809c23` | `c9352813-…627460` |
+| odrážka 1 — tučné / text | `03e81e56-…ffd913` / `09f0c9f7-…363944` | `cd2d0122-…809c27` / `5e0b1f00-…192626` | `c9352813-…627464` / `5b6ecf6e-…94aedc` |
+| odrážka 2 — tučné / text | `5df32ee1-…8734d51e` / `0c32000f-…b22a08e` | `cd2d0122-…809c2b` / `f9f91647-…c658c8` | `c9352813-…627468` / `eb46b0bc-…d89b282` |
+| odrážka 3 — tučné / text | `b1a9e7f5-…c7d0fc4de5` / `cc850fe4-…c450179` | `cd2d0122-…809c2f` / `69336865-…9a6ede` | `c9352813-…62746c` / `1193f119-…ba776d26` |
+| přebytečný tučný úsek v odrážce 2 (mazat i s ocáskem) | `bf073eaf-…8fd65` + `…8fd64` | — | `952f4ef2-…ddf43c` + `…ddf43a`/`…ddf43b` |
+
+Prefixy: sekce 1 `39d70114-ade1-45a0-146e-b7e539179…` (štítky) a
+`3b1868e6-f203-9b85-0f6f-e9fb15f06…`, sekce 2
+`cd2d0122-db01-458c-4f72-f9ec68809…`, sekce 3
+`c9352813-4932-9bb7-94f1-70852d627…`.
+
+### Galerie
+
+| Sekce | obal `div.slider` | `ImageSlider__Collection` | `PopUpSlider__Collection` |
+|---|---|---|---|
+| 1 | | `3fcad9d6-7d88-259e-8f1c-ac6ec5fa0325` | `3fcad9d6-…5fa0312` |
+| 2 | `cd2d0122-…809c37` | `cd2d0122-…809c55` | `cd2d0122-…809c42` |
+| 3 | | `c9352813-…627492` | `c9352813-…62747f` |
+
+Filtr se zapisuje `set_settings`, klíč `filters`:
+
+```json
+[{"fieldSlug":"produkt-2","operator":"equals","value":"<id možnosti>"}]
+```
+
+## ID možností galerie (`produkt-2`, kolekce `646d5c52aab44e9fcf5974b8`)
+
+| Možnost | id |
+|---|---|
+| Výstrče | `5273a08b6e2765b73ab9f3a08e4dc494` |
+| Lékárenské znaky | `fa6d1c87bd1ff6f53657605679f5335c` |
+| Zámečnické konstrukce | `a637df9de32203cc02f75910d11cebc6` |
+| Atypické zámečnické konstrukce | `e54aa444019c4c77239680077d731afb` |
+| Opracování a prodej plexiskla a polykarbonátu | `63f56c938779601245607e12a7c15fcb` |
+| Velkoformátový digitální tisk | `63c0a542d2775da0427b15117791169a` |
+| Řezaná grafika | `5c3a901c9efde2edfb74d2c537e91f50` |
+| Další druhy polepů | `e85204ffd45cfebffe921b4d4d9da972` |
+| Vstupní portály na míru | `bf8bafc8e6e5fa89b90389d393995c26` |
+| Architektonické světelné prvky | `a7f0413a080fd62e1c1fcefaa590197c` |
+| Reklamní vlajky | `0d408807ca468d67d92b4ed9ebc70902` |
+| Prvky podpory prodeje | `f3e37d06557e5f83e1c44d03bc4a8523` |
+| Led displaye | `33454324a752154a9603b176f66709ed` |
+| Světelné panely | `68a38dad7ecc982882ae39962a6c62e6` |
+| Intarzie | `9ea07e6357b2e3f0f9ab291e2def6c46` |
+| Reklamní tabule | `9f7038c9681b452bf81af8afb3ac1959` |
+| Menuboardy/infoboardy | `c509110babf75fd1ad0593238cb30bf2` |
+| Designová svítidla | `16381f137ade6350f8c73b9ac418b241` |
+| „Žárovkové" světelné nápisy | `673549040e1cb35f4d4cf5552c7d3664` |
+| Neonová reklama | `65991def267b320e4fab565ebc8569cb` |
+| Mechové stěny | `0bcc5407ab1bb6b1feb27be391530550` |
+| Světelná čísla domů | `40a173437d4414b7edfaa4bf3c122a97` |
+| Designové lampy | `791c3122d677866f082918bf37a67495` |
+
+### Sekce bez galerie v CMS
+
+Pro čtyři sekce z návrhu **možnost v `produkt-2` neexistuje**:
+
+- Atypické výstrče
+- Designové obrazy
+- LED obrazovky
+- Reklama z cortenového plechu
+
+Přes API se do `Option` pole nová možnost přidat nedá
+(`update_collection_field` umí jen jméno, nápovědu a povinnost). U těchto
+sekcí se proto **skryje celý obal `div.slider`** (`set_visibility` na
+`false`). U „LED obrazovek" a „Reklamy z cortenového plechu" to odpovídá
+i živému webu — galerii tam nemají.

--- a/docs/produktove-stranky-stav.md
+++ b/docs/produktove-stranky-stav.md
@@ -162,6 +162,22 @@ a zásah do něj se projeví všude.
 a ze sitemapy je vyřazuje jen nastavení u stránky. API na robots.txt
 nesahá.
 
+### I. Slugy — pozor při prohazování
+
+Dev stránky mají kratší slugy než ostré verze. Až se budou prohazovat
+(stará stránka `…-old`, nová na ostrý slug), musí nová stránka převzít
+**slug staré**, jinak se rozbijí URL i odkazy v menu.
+
+| Dev slug | Ostrý slug, který má převzít |
+|---|---|
+| `vystrce-lekarenske-znaky` | `vystrce-lekarenske-znaky` |
+| `velkoformatovy-tisk` | `velkoformatovy-tisk` |
+| `vstupni-portaly` | `architektonicke-prvky-vstupni-portaly-vlajky` |
+| `prvky-podpory-prodeje` | `prvky-podpory-prodeje-led-technologie` |
+| `svetelne-panely-a-tabule` | `tabule-a-svetelne-panely` |
+| `designova-svitidla` | `designova-a-interierova-svitidla-specialni-projekty` |
+| `zamecnicke-konstrukce` | `zamecnicke-konstrukce-na-miru-opracovani-plexiskla` |
+
 ## Co je jinak, než by mělo být
 
 - **Sedmá sekce Designových svítidel** („Reklama z cortenového plechu")
@@ -218,6 +234,10 @@ nesahá.
   struktura, kotvy i galerie hotové jsou. Až limit povolí (nebo po
   upgradu), stačí u každé sekce zavolat `download_assets` a fotky
   nahrát; postup je popsaný v `produktove-stranky-figma.md`.
+- **Kotvy ověřené proti menu.** Všech 23 id sekcí na nových stránkách
+  sedí znak po znaku s odkazy, které navbar na živém webu používá.
+  Ověřeno vytažením `href="/produkty/…#…"` z živého HTML a porovnáním
+  s `attributes.id` každé sekce přes API.
 - **Vizuální kontrola v prohlížeči.** Playwright se v tomhle prostředí
   přes proxy nedostane ven, takže stránky nejsou prohlédnuté očima —
   jen ověřené přes API. Než se bude publikovat, projdi je v Designeru.

--- a/docs/produktove-stranky-stav.md
+++ b/docs/produktove-stranky-stav.md
@@ -2,54 +2,49 @@
 
 Živý stav rozpracované série. **Čte se jako první**, když práce pokračuje
 v nové session. Postup, mapa framů a technické limity jsou v
-`produktove-stranky-figma.md` — tenhle soubor říká, co je hotové a co dál.
+`produktove-stranky-figma.md`, texty z návrhu v
+`produktove-stranky-texty.md`, element ID v `produktove-stranky-id-mapa.md`.
 
 ## Rozhodnutí zadavatele (3. 9. 2026)
 
 1. **Sekce, které jsou v návrhu, ale nevede na ně odkaz z menu**
    („Atypické zámečnické konstrukce", „Atypické výstrče", „Designové
    obrazy") — **postavit** a **přidat odkaz do menu**. V sekundárních
-   locale je odkaz **skrýt**, protože tam obsah zatím neexistuje: na
-   odkaz se dá combo třída `localization-show-only_cs` (existuje, přepíná
-   ji `src/eldr.css` podle `lang-*` na `<body>`). Každá sekce dostane
-   vlastní `id` odvozené ze svého názvu a musí být správně napárovaná na
-   galerii v CMS.
-
-2. **Publikuje se jednou, až bude hotová celá série.** Ne po jednotlivých
-   stránkách — každý publish pouští ven i cizí rozdělanou práci.
-
-3. **Obrázky se do stránek nevkládají.** Nahrají se do assetů, zatřídí do
-   `Produkty/<název stránky>/`, pojmenují podle sekce a dostanou alt text.
-   Ve stránce zůstane obrázek zděděný ze vzoru. Důvod je limit popsaný
-   v `produktove-stranky-figma.md`: zápis přes API rozbije `sizes`
+   locale je odkaz **skrýt** combo třídou `localization-show-only_cs`.
+2. **Publikuje se jednou, až bude hotová celá série.**
+3. **Obrázky se do stránek nevkládají** — zápis přes API rozbije `sizes`
    a obrázek zešedne. Člověk je v Designeru překlikne podle seznamu níž.
-
-4. **Nejednoznačnosti se neobcházejí.** Zvolí se nejbližší rozumná
-   varianta, pokračuje se dál a rozhodnutí se zapíše do „Rozhodnutí
-   učiněná za pochodu".
+4. **Nejednoznačnosti se neobcházejí** — zvolí se nejbližší rozumná
+   varianta a zapíše se do „Rozhodnutí učiněná za pochodu".
 
 ## Stav stránek
 
-| Stránka | Figma | Struktura | Texty | Galerie | Obrázky do assetů |
-|---|---|---|---|---|---|
-| Orientační systémy | `1921:2203` | hotovo | hotovo | hotovo | hotovo |
-| Zámečnické konstrukce | `1926:2736` | | | | |
-| Výstrče, lékárenské znaky | `1886:2143` | | | | |
-| Velkoformátový tisk | `1929:3364` | | | | |
-| Vstupní portály | `1953:2003` | | | | |
-| Prvky podpory prodeje | `1958:2631` | | | | |
-| Světelné panely a tabule | `1438:6615` | | | | |
-| Designová svítidla | `2179:2707` | | | | |
+Všech sedm stránek stojí v `/dev/`, je vyřazených ze sitemapy
+a nepublikovaných.
 
-Stránky vznikají v `/dev/<slug>`, vyřazené ze sitemapy, nepublikované.
+| Stránka | `/dev/` slug | pageId | Sekcí | Struktura | Texty | Galerie | Obrázky |
+|---|---|---|---|---|---|---|---|
+| Orientační systémy | `orientacni-systemy` | `6401fcf4e07002bda0fea1d5` | 1 | hotovo | hotovo | hotovo | ráno |
+| Zámečnické konstrukce | `zamecnicke-konstrukce` | `6a9aa29d3f076848d52e7d63` | 3 | hotovo | hotovo | hotovo | ráno |
+| Výstrče, lékárenské znaky | `vystrce-lekarenske-znaky` | `6a9aa82d1bc055833d458566` | 3 | hotovo | hotovo | 2 ze 3 | ráno |
+| Velkoformátový tisk | `velkoformatovy-tisk` | `6a9aada633cfcc4604230b5f` | 4 | hotovo | hotovo | 3 ze 4 | ráno |
+| Vstupní portály | `vstupni-portaly` | `6a9ab01047299df13695660e` | 3 | hotovo | hotovo | hotovo | ráno |
+| Prvky podpory prodeje | `prvky-podpory-prodeje` | `6a9ab0f0fdf55c29d79dc962` | 3 | hotovo | hotovo | 2 ze 3 | ráno |
+| Světelné panely a tabule | `svetelne-panely-a-tabule` | `6a9ab1e40aec35eaf9d1edec` | 4 | hotovo | hotovo | hotovo | ráno |
+| Designová svítidla | `designova-svitidla` | `6a9ab353346c1fa008c113d7` | 7 | hotovo\* | hotovo | 6 ze 7 | ráno |
+
+\* Sedmá sekce („Reklama z cortenového plechu") se musela **postavit
+ručně** — vzorová stránka má jen šest produktových sekcí a API neumí
+sekci naklonovat. Postavená sekce je textová: má oddělovač, štítky,
+nadpis a tři odstavce, ale **nemá produktovou fotku, tlačítko ani
+galerii** a chybí jí odsazovací utility třídy (builder je odmítl).
+Viz „Co je jinak, než by mělo být".
 
 ## Sekce podle návrhu
 
-Ověřeno proti návrhu, ne jen proti menu — návrh má u některých stránek
-sekci navíc. Hvězdička = sekce bez odkazu v menu, řeší se podle
-rozhodnutí 1.
+Hvězdička = sekce bez odkazu v menu (rozhodnutí 1).
 
-| Stránka | Sekce (pořadí podle návrhu) |
+| Stránka | Sekce v pořadí podle návrhu |
 |---|---|
 | Orientační systémy | `orientacni-systemy` |
 | Zámečnické konstrukce | `zamecnicke-konstrukce`, `atypicke-zamecnicke-konstrukce`\*, `opracovani-a-prodej-plexiskla` |
@@ -60,42 +55,171 @@ rozhodnutí 1.
 | Světelné panely a tabule | `svetelne-panely`, `intarzie`, `reklamni-tabule`, `menuboardy` |
 | Designová svítidla | `designova-svitidla`, `zarovkove-svetelne-napisy`, `neonove-napisy`, `mechove-steny`, `reklama-z-cortenoveho-plechu`, `svetelna-cisla-domu`, `stojaci-lampy` |
 
-U každé stránky se počet sekcí ověřuje ze screenshotu návrhu, ne z počtu
-karet v rozcestníku — u Zámečnických se právě takhle našla třetí sekce,
-kterou rozcestník nemá.
-
 ## Co člověk udělá ráno
 
-Průběžně doplňovaný seznam. Každá položka musí být proveditelná bez
-dohledávání — plná cesta k assetu i místo ve stránce.
+### A. Obrázky — proč to nejde přes API
 
-### Orientační systémy — `/dev/orientacni-systemy`
+Zápis obrázku přes API rozbije atribut `sizes` a fotka se zobrazí
+rozmazaně (detail v `produktove-stranky-figma.md`). Každý obrázek se
+proto musí **v Designeru vybrat znovu ručně** — tím se `sizes`
+přepočítá. Týká se to hero fotky, obrázků na kartách rozcestníku
+a produktových fotek v sekcích.
 
-1. Hero obrázek → vybrat `Produkty / Orientační systémy / hero.webp`
-2. Produktová fotka v sekci „Orientační systémy budov a areálů" — jsou
-   tam **tři** obrázky přes sebe (varianty cs/en/de) → všem třem vybrat
-   `Produkty / Orientační systémy / orientacni-systemy-budov-a-arealu.png`
+**Produktová fotka má tři jazykové sloty** (`localization-show-only_cs`
+/ `_en` / `_de`). Dokud nejsou překlady, stačí vyplnit **cs**; ostatní
+dva se doplní s překlady.
 
-Důvod: obojí se do stránky dostalo přes API, takže má rozbité `sizes`
-a zobrazuje se rozmazaně. Překliknutím v Designeru se to spraví.
+### B. Hero fotky — konkrétní soubory
+
+Návrh používá tytéž hero fotky, jaké má dnes živý web. Stačí je
+v Designeru vybrat z assetů:
+
+| Stránka | Asset |
+|---|---|
+| Výstrče | `Sětelné znaky - Profil 8 (0001) 1.png` (T-Mobile, `6a3a24133f8238fbc7825404`) |
+| Velkoformátový tisk | `velkoformat-hero.webp` (`68b4b2d487e457b5e3ffbe1e`) |
+| Vstupní portály | `vstupni-portaly-hero.webp` (`68b4a90842e2b142ba3d89b1`) |
+| Prvky podpory prodeje | `Upscale Media Transformed.webp` (`6910d644c29abfe842ab67ab`) |
+| Světelné panely a tabule | `Sětelné znaky - Profil 8 (0001) 2.avif` (`68c02a773967296e4cfa1995`) |
+| Designová svítidla | `Upscale Media Transformed (1).webp` (`6910d9666c5dbe31a0507e27`) |
+| Zámečnické konstrukce | `…_IMG_3839.webp` (`688755592e0a6fffa66ae8c6`) — ověřit proti návrhu, hero se z Figmy nepodařilo stáhnout |
+
+Ověřeno porovnáním hero fotky z návrhu proti živé stránce (Výstrče:
+shoda). U ostatních stránek je to tentýž vzorec.
+
+### C. Produktové fotky, které už na webu jsou
+
+Tyhle stačí vybrat z assetů, jsou to přesně ty ze staré verze stránky:
+
+| Stránka / sekce | cs | en | de |
+|---|---|---|---|
+| Výstrče / `#vystrce` | `Vystrc se zasunutym plexi 1.png` | `Vystrc se zasunutym plexi 6_EN.png` | `Vystrc se zasunutym plexi 4_DE.png` |
+| Světelné panely / `#svetelne-panely` | `Svetelny panel.png` | `Svetelny panel_EN.png` | `Svetelny panel_DE.png` |
+| Světelné panely / `#intarzie` | `Plexiintarzie podlozena.png` | `Plexiintarzie podlozena_EN.png` | `Plexiintarzie podlozena_DE.png` |
+| Světelné panely / `#reklamni-tabule` | `Reklamni tabule.png` | `Reklamni tabule_EN.png` | `Reklamni tabule_DE.png` |
+| Světelné panely / `#menuboardy` | `UHK 1.avif` | — | — |
+| Zámečnické / `#zamecnicke-konstrukce` | `zamecnicke-konstrukce.jpg` (`6a9aa48beb68c246d9a5deef`) | — | — |
+| Zámečnické / `#atypicke-zamecnicke-konstrukce` | `atypicke-zamecnicke-konstrukce.jpg` (`6a9aa48badd0e01507de20f2`) | — | — |
+| Zámečnické / `#opracovani-a-prodej-plexiskla` | `opracovani-a-prodej-plexiskla.jpg` (`6a9aa48cadd0e01507de2121`) | — | — |
+| Orientační systémy / hero | `Produkty / Orientační systémy / hero.webp` | — | — |
+| Orientační systémy / sekce | `Produkty / Orientační systémy / orientacni-systemy-budov-a-arealu.png` (do všech tří slotů) | | |
+
+Zámečnické fotky jsou ve složce **Produkty / Zámečnické konstrukce/**.
+
+### D. Produktové fotky, které v assetech nejsou
+
+U zbylých sekcí návrh ukazuje fotku, která na starém webu není a **z
+Figmy se ji nepodařilo stáhnout** (viz „Co zůstalo nedodělané"). Ve
+stránce je zatím zděděná fotka z 3D nápisů. Vyber prosím vlastní fotku
+z galerie daného produktu — je to:
+
+- **Velkoformátový tisk** — `#uvod` (bankomat era), `#rezana-grafika`
+  (interiér KFC), `#dalsi-druhy-polepu` (pobočka ČSOB),
+  `#designove-obrazy` (obrazy v kavárně)
+- **Vstupní portály** — `#vstupni-portaly` (zelený prosvětlený portál),
+  `#architektonicke-prvky` (hvězda Mercedes na střeše), `#vlajky`
+  (vlajka ČSOB na fasádě)
+- **Prvky podpory prodeje** — `#prvky-podpory-prodeje` (černé stojany
+  MG), `#led-displaye` (žlutý totem OLVAN); `#led-obrazovky` fotku
+  v návrhu vůbec nemá
+- **Designová svítidla** — všech sedm sekcí
+- **Výstrče** — `#atypicke-vystrce` (výstrč Petřín Park),
+  `#lekarenske-znaky` (zelený lékárenský kříž)
+- **Zámečnické** — hero
+
+### E. Obrázky na kartách rozcestníku
+
+Karty na všech nových stránkách mají zděděné fotky z 3D nápisů. V návrhu
+mají fotku odpovídající své sekci — vyber ji stejným způsobem.
+
+### F. Sekce bez galerie v CMS
+
+Čtyři sekce z návrhu nemají v poli **Fotogalerie** (kolekce Fotografie)
+svou možnost a přes API ji nejde přidat. U těch je galerie **skrytá**:
+
+| Sekce | Stránka |
+|---|---|
+| Atypické výstrče | Výstrče |
+| Designové obrazy | Velkoformátový tisk |
+| LED obrazovky | Prvky podpory prodeje |
+| Reklama z cortenového plechu | Designová svítidla |
+
+U „LED obrazovek" a „cortenu" je to stejné i na živém webu. U zbylých
+dvou: až v CMS založíš možnost a otaguješ fotky, stačí galerii odkrýt
+a nastavit filtr.
+
+### G. Menu
+
+Až budou stránky odsouhlasené, je potřeba do komponenty `Navbar_2024-12`
+přidat tři odkazy — `#atypicke-vystrce`, `#atypicke-zamecnicke-konstrukce`
+a `#designove-obrazy` — s combo třídou `localization-show-only_cs`.
+**Zatím to není udělané**, protože navbar je společný pro celý web
+a zásah do něj se projeví všude.
+
+### H. robots.txt
+
+`Disallow: /dev/` do Site settings → SEO. Dev stránky nemají `noindex`
+a ze sitemapy je vyřazuje jen nastavení u stránky. API na robots.txt
+nesahá.
+
+## Co je jinak, než by mělo být
+
+- **Sedmá sekce Designových svítidel** („Reklama z cortenového plechu")
+  je postavená ručně a je jen textová — bez fotky, bez tlačítka „Nezávazně
+  poptat", bez galerie a bez odsazovacích tříd. Nejrychlejší oprava je
+  v Designeru zduplikovat sousední produktovou sekci, přepsat texty
+  (jsou v `produktove-stranky-texty.md`), nastavit id
+  `reklama-z-cortenoveho-plechu` a ručně postavenou sekci smazat.
+- **Sedmá karta rozcestníku** na téže stránce je postavená stejným
+  způsobem. Odkaz i texty sedí, ale fotka je zástupná.
+- **Ikony v bloku `section_layout253`** zůstaly zděděné z 3D nápisů
+  (štětec, štít). V návrhu jsou jinde zaškrtávátka nebo otazník. Chce to
+  přepsat `code` v HTML embedu, nebo nechat být — je to drobnost.
 
 ## Rozhodnutí učiněná za pochodu
 
-Věci, kde návrh nedával jednoznačnou odpověď a zvolila se varianta, kterou
-je vhodné zkontrolovat.
+- **Chybný text karty u Výstrčí.** Návrh má u karty „Světelné výstrče"
+  popis, který patří k „Atypickým výstrčím" (doslovná kopie). Použil se
+  popis odvozený z vlastní sekce, aby karta popisovala svůj produkt.
+- **Šest odrážek u „Polepů"** (Velkoformátový tisk) se sloučilo do tří —
+  šablona má tři položky seznamu a přes API nejde další přidat. Obsah
+  zůstal celý, jen po dvojicích: vozidla + výlohy, perforované + krycí,
+  podlahy + prvky pro šeroslepé.
+- **Blok „Výstrče různých typů"** má v návrhu čtyři varianty pod sebou,
+  šablona `section_layout253` má dva sloupce. Varianty se rozdělily
+  2 + 2, obsah zůstal celý.
+- **Dvojblok „Vystouplá / Podložená plexiintarzie"** (Světelné panely) se
+  přesunul do `section_layout253` hned za sekci Intarzie — tvarem je to
+  přesně blok pro dvě položky.
+- **Sekce „Lékárenské znaky"** má v návrhu tučný odstavec a dvě krátké
+  odrážky; převedlo se to na tři odrážky (Oprávnění, Sortiment, Vhodné
+  pro), aby to sedělo do šablony.
+- **Popisy karet u Designových svítidel** se odvodily z úvodních vět
+  sekcí — v návrhu jsou v tak nízkém rozlišení, že se nedaly přečíst.
+- **Kroky procesu (`section_process-link`)** zůstaly, i když je návrh
+  u nových stránek nekreslí. Zadání znělo držet se struktury dvou
+  hotových stránek.
+- **Tlačítko v bloku `section_layout253`** („Jak probíhá výroba?")
+  zůstalo, i když ho návrh v tomhle bloku nemá. Je to funkční odkaz na
+  sekci níž.
+- **Pořadí štítků v hero.** Šablona je má v pořadí Kompletní servis →
+  Úsporné LED → Odborná montáž → Životnost desítky let, návrh přesně
+  obráceně. Nové stránky mají pořadí podle návrhu.
+- **Štítky v produktových sekcích.** Šablona má tři, návrh dva a oba
+  s ikonou. Maže se první štítek (jediný bez ikony) a druhému se přidá
+  odsazení — levnější než ikonu dostavovat.
 
-- **Ikony ve dvousloupcovém bloku** (Orientační systémy): návrh ukazuje
-  otazník v plném kolečku, ale ten symbol se v souboru nepodařilo najít
-  jako samostatný uzel. Použilo se inline SVG ve stylu zbytku sady —
-  kolečko v barvě z třídy, otazník bílý.
-- **Produktová fotka ve třech jazykových slotech** (Orientační systémy):
-  fotka rozcestníku neobsahuje překládaný text, takže do všech tří
-  variant šel tentýž soubor.
+## Co zůstalo nedodělané
 
-## Neuzavřené věci pro zadavatele
-
-- **`Disallow: /dev/` do robots.txt** (Site settings → SEO). Dev stránky
-  nemají `noindex` a ze sitemapy je vyřazuje jen nastavení u stránky.
-  API na robots.txt nesahá.
-- **Překlady EN a DE.** Nové stránky je mají prázdné; řeší se až po
-  dokončení všech českých verzí. Do té doby se neprohazují slugy.
+- **Figma MCP došly volání** („You've reached the Figma MCP tool call
+  limit on the Starter plan"). Návrh se proto četl ze screenshotů framů
+  pořízených dřív a **obrázky z návrhu se nedaly stáhnout ani nahrát do
+  assetů**. To je jediná část zadání, která se nesplnila — texty,
+  struktura, kotvy i galerie hotové jsou. Až limit povolí (nebo po
+  upgradu), stačí u každé sekce zavolat `download_assets` a fotky
+  nahrát; postup je popsaný v `produktove-stranky-figma.md`.
+- **Vizuální kontrola v prohlížeči.** Playwright se v tomhle prostředí
+  přes proxy nedostane ven, takže stránky nejsou prohlédnuté očima —
+  jen ověřené přes API. Než se bude publikovat, projdi je v Designeru.
+- **Překlady EN a DE** jsou u nových stránek prázdné. Slugy se
+  neprohazují, dokud nebudou hotové.

--- a/docs/produktove-stranky-stav.md
+++ b/docs/produktove-stranky-stav.md
@@ -1,0 +1,101 @@
+# Přestavba produktových stránek — stav a zadání
+
+Živý stav rozpracované série. **Čte se jako první**, když práce pokračuje
+v nové session. Postup, mapa framů a technické limity jsou v
+`produktove-stranky-figma.md` — tenhle soubor říká, co je hotové a co dál.
+
+## Rozhodnutí zadavatele (3. 9. 2026)
+
+1. **Sekce, které jsou v návrhu, ale nevede na ně odkaz z menu**
+   („Atypické zámečnické konstrukce", „Atypické výstrče", „Designové
+   obrazy") — **postavit** a **přidat odkaz do menu**. V sekundárních
+   locale je odkaz **skrýt**, protože tam obsah zatím neexistuje: na
+   odkaz se dá combo třída `localization-show-only_cs` (existuje, přepíná
+   ji `src/eldr.css` podle `lang-*` na `<body>`). Každá sekce dostane
+   vlastní `id` odvozené ze svého názvu a musí být správně napárovaná na
+   galerii v CMS.
+
+2. **Publikuje se jednou, až bude hotová celá série.** Ne po jednotlivých
+   stránkách — každý publish pouští ven i cizí rozdělanou práci.
+
+3. **Obrázky se do stránek nevkládají.** Nahrají se do assetů, zatřídí do
+   `Produkty/<název stránky>/`, pojmenují podle sekce a dostanou alt text.
+   Ve stránce zůstane obrázek zděděný ze vzoru. Důvod je limit popsaný
+   v `produktove-stranky-figma.md`: zápis přes API rozbije `sizes`
+   a obrázek zešedne. Člověk je v Designeru překlikne podle seznamu níž.
+
+4. **Nejednoznačnosti se neobcházejí.** Zvolí se nejbližší rozumná
+   varianta, pokračuje se dál a rozhodnutí se zapíše do „Rozhodnutí
+   učiněná za pochodu".
+
+## Stav stránek
+
+| Stránka | Figma | Struktura | Texty | Galerie | Obrázky do assetů |
+|---|---|---|---|---|---|
+| Orientační systémy | `1921:2203` | hotovo | hotovo | hotovo | hotovo |
+| Zámečnické konstrukce | `1926:2736` | | | | |
+| Výstrče, lékárenské znaky | `1886:2143` | | | | |
+| Velkoformátový tisk | `1929:3364` | | | | |
+| Vstupní portály | `1953:2003` | | | | |
+| Prvky podpory prodeje | `1958:2631` | | | | |
+| Světelné panely a tabule | `1438:6615` | | | | |
+| Designová svítidla | `2179:2707` | | | | |
+
+Stránky vznikají v `/dev/<slug>`, vyřazené ze sitemapy, nepublikované.
+
+## Sekce podle návrhu
+
+Ověřeno proti návrhu, ne jen proti menu — návrh má u některých stránek
+sekci navíc. Hvězdička = sekce bez odkazu v menu, řeší se podle
+rozhodnutí 1.
+
+| Stránka | Sekce (pořadí podle návrhu) |
+|---|---|
+| Orientační systémy | `orientacni-systemy` |
+| Zámečnické konstrukce | `zamecnicke-konstrukce`, `atypicke-zamecnicke-konstrukce`\*, `opracovani-a-prodej-plexiskla` |
+| Výstrče | `vystrce`, `atypicke-vystrce`\*, `lekarenske-znaky` |
+| Velkoformátový tisk | `uvod`, `rezana-grafika`, `dalsi-druhy-polepu`, `designove-obrazy`\* |
+| Vstupní portály | `vstupni-portaly`, `architektonicke-prvky`, `vlajky` |
+| Prvky podpory prodeje | `prvky-podpory-prodeje`, `led-displaye`, `led-obrazovky` |
+| Světelné panely a tabule | `svetelne-panely`, `intarzie`, `reklamni-tabule`, `menuboardy` |
+| Designová svítidla | `designova-svitidla`, `zarovkove-svetelne-napisy`, `neonove-napisy`, `mechove-steny`, `reklama-z-cortenoveho-plechu`, `svetelna-cisla-domu`, `stojaci-lampy` |
+
+U každé stránky se počet sekcí ověřuje ze screenshotu návrhu, ne z počtu
+karet v rozcestníku — u Zámečnických se právě takhle našla třetí sekce,
+kterou rozcestník nemá.
+
+## Co člověk udělá ráno
+
+Průběžně doplňovaný seznam. Každá položka musí být proveditelná bez
+dohledávání — plná cesta k assetu i místo ve stránce.
+
+### Orientační systémy — `/dev/orientacni-systemy`
+
+1. Hero obrázek → vybrat `Produkty / Orientační systémy / hero.webp`
+2. Produktová fotka v sekci „Orientační systémy budov a areálů" — jsou
+   tam **tři** obrázky přes sebe (varianty cs/en/de) → všem třem vybrat
+   `Produkty / Orientační systémy / orientacni-systemy-budov-a-arealu.png`
+
+Důvod: obojí se do stránky dostalo přes API, takže má rozbité `sizes`
+a zobrazuje se rozmazaně. Překliknutím v Designeru se to spraví.
+
+## Rozhodnutí učiněná za pochodu
+
+Věci, kde návrh nedával jednoznačnou odpověď a zvolila se varianta, kterou
+je vhodné zkontrolovat.
+
+- **Ikony ve dvousloupcovém bloku** (Orientační systémy): návrh ukazuje
+  otazník v plném kolečku, ale ten symbol se v souboru nepodařilo najít
+  jako samostatný uzel. Použilo se inline SVG ve stylu zbytku sady —
+  kolečko v barvě z třídy, otazník bílý.
+- **Produktová fotka ve třech jazykových slotech** (Orientační systémy):
+  fotka rozcestníku neobsahuje překládaný text, takže do všech tří
+  variant šel tentýž soubor.
+
+## Neuzavřené věci pro zadavatele
+
+- **`Disallow: /dev/` do robots.txt** (Site settings → SEO). Dev stránky
+  nemají `noindex` a ze sitemapy je vyřazuje jen nastavení u stránky.
+  API na robots.txt nesahá.
+- **Překlady EN a DE.** Nové stránky je mají prázdné; řeší se až po
+  dokončení všech českých verzí. Do té doby se neprohazují slugy.

--- a/docs/produktove-stranky-texty.md
+++ b/docs/produktove-stranky-texty.md
@@ -1,0 +1,314 @@
+# Texty produktových stránek podle návrhu
+
+Přepis z Figma návrhu. **Zdroj pravdy pro obsah** — když se staví stránka,
+bere se text odsud, ne z živého webu (živý web má starší verzi).
+
+Návrh se četl ze screenshotů framů uložených mimo repozitář
+(`f1.png`–`f7.png` ve scratchpadu session). Figma MCP narazilo na limit
+Starter plánu, takže screenshoty jsou jediný zdroj — proto je přepis tady.
+
+Značení: **\*** = sekce, na kterou nevede odkaz z menu (řeší se podle
+rozhodnutí 1 v `produktove-stranky-stav.md`).
+
+Společné pro všechny stránky:
+
+- rozcestník (`section_layout400`) uvádí věta **„Podívejte se blíže na to,
+  co vás zajímá. Pamatujte, všechno jde uzpůsobit:"**
+- tlačítko v každé produktové sekci: **„Nezávazně poptat"**
+- konec stránky (Jak probíhá výroba, Důvěřují nám, Záruka) je zděděný
+  ze vzoru, návrh ho nemění
+
+---
+
+## Výstrče, lékárenské znaky
+
+**Hero H1:** Výstrče, lékárenské znaky
+**Podnadpis:** Už z dálky zajišťují skvělou viditelnost reklamy. Vyrábíme velké množství provedení, variant a tvarů.
+**Štítky hero:** Životnost desítky let · Úsporné LED · Odborná montáž · Kompletní servis
+
+**Karty rozcestníku**
+
+| Karta | Text |
+|---|---|
+| Světelné výstrče | Reklama, která svítí dnem i nocí. LED podsvětlení zajišťuje rovnoměrnou viditelnost i za špatného počasí. |
+| Atypické výstrče | Výstrč ve tvaru vašeho symbolu je reklama, kterou si zákazníci zapamatují. Tvar mluví za vás – i bez jediného slova. |
+| Lékárenské znaky | Lékárenské znaky jsou pod autorským zákonem. A my patříme mezi několik málo firem, které mají oprávnění k jejich výrobě. |
+
+**Blok `section_layout253`** (nadpis + odstavec + odrážky)
+
+> **Výstrče různých typů a provedení na míru**
+>
+> Výroba je možná ve velkém množství provedení, variant a tvarů. Může se jednat o čtvercovou či kruhovou výstrč, ale také může být tvarována dle libosti (např. zub pro zubní ambulanci). Varianty výstrčí:
+>
+> - **Světelná výstrč:** výstrč s osvětlením pro lepší viditelnost reklamy.
+> - **Výstrč s intarzií:** designová výstrč s tvarovanými světelnými 3D znaky pro jedinečný vzhled.
+> - **Výstrč na míru:** výstrč přizpůsobená specifickým požadavkům klienta.
+> - **Nesvětelná výstrč:** stylová a nenápadná výstrč, ideální pro elegantní a moderní prezentace.
+
+### 1. Světelné výstrče — `#vystrce`
+
+Štítky: Nepřehlédnutelné · Zaujme i kolemjdoucí
+
+Reklama, která svítí dnem i nocí. LED podsvětlení zajišťuje rovnoměrnou viditelnost i za špatného počasí i po setmění.
+
+- **Grafika:** čelní strana výstrče je polepena tištěnou nebo řezanou grafikou. Tvar výstrče i grafické zpracování lze přizpůsobit dle libosti, včetně atypických tvarů.
+- **Materiál:** rám tvoří hliníková konstrukce, čelní plocha je z prosvíceného plexiskla nebo jiného deskového materiálu. K vnitřnímu rámu jsou přivařeny konzoly určené k upevnění výstrče na zeď.
+- **Vhodné pro:** provozovny, které potřebují být vidět ze všech stran – obchody na frekventovaných ulicích, restaurace, hotely a všude tam, kde reklama musí upoutat pozornost i za tmy.
+
+### 2. Atypické výstrče — `#atypicke-vystrce` *
+
+Štítky: Tvar podle brandingu · Nápadné na první pohled
+
+Viditelná reklama na ocelové konstrukci je nepřehlédnutelná i z velké dálky a proto i účinná.
+
+- **Grafika:** tvar výstrče kopíruje siluetu symbolu vašeho oboru – zub, nůžky, srdce, klíč, sklenici nebo cokoliv, co zákazník okamžitě spojí s vaším podnikáním.
+- **Materiál:** rám tvoří hliníková konstrukce, čelní plocha je z prosvíceného plexiskla nebo jiného deskového materiálu. K vnitřnímu rámu jsou přivařeny konzoly určené k upevnění výstrče na zeď.
+- **Vhodné pro:** provozovny, které mají ikonický symbol okamžitě spojený s oborem – zubní ordinace (zub), kadeřnictví (nůžky), kavárny (šálek), vinotéky (vinná réva), zálož­ny (klíč).
+
+### 3. Lékárenské znaky — `#lekarenske-znaky`
+
+Štítky: Standardizované · Rozpoznatelné
+
+Jsou chráněny autorským zákonem a slouží k jednotnému označení lékáren a zdravotnických zařízení. Nabízíme širokou škálu světelných i nesvětelných nápisů „Lékárna", polepů výloh, podlah a pultů, a dalšího označení.
+
+- **Oprávnění:** jsme jednou z mála firem oprávněných k výrobě lékárenských křížů. Spolupráce s Ing. arch. Flašarem nám umožnila podílet se na výrobě velkého množství těchto křížů.
+- **Sortiment:** světelné i nesvětelné nápisy „Lékárna", polepy výloh, podlah a pultů a další doplňkové lékárenské značení.
+- **Vhodné pro:** označení lékáren a označení ordinací.
+
+---
+
+## Velkoformátový tisk
+
+**Hero H1:** Velkoformátový digitální tisk, řezaná grafika, polepy
+**Štítky hero:** 37 let zkušeností · Na míru · Vlastní grafické studio
+
+**Karty rozcestníku**
+
+| Karta | Text |
+|---|---|
+| Velkoformátový tisk | Lze detailně vyhotovit jakýkoliv design a barevnou kombinaci. |
+| Řezaná grafika | Nápisy vyřezané ze samolepicí fólie = dlouhá životnost. |
+| Polepy | Reklamní polepy vozů, výloh, oken i podlah. |
+| Designové obrazy | Velkoformátové obrazy a nástěnné grafiky pro restaurace, kavárny, retail i firemní prostory. |
+
+### 1. Velkoformátový digitální tisk — `#uvod`
+
+Štítky: Interiér i exteriér · Na míru
+
+Digitální tisk často kombinujeme s řezanou grafikou, abychom dosáhli optimálního výsledku z hlediska vzhledu i trvanlivosti.
+
+- **Materiály:** je možné potisknout papír, samolepicí fólii, translucentní (prosvětlovací) fólii, perforovanou fólii, banner a textilní materiály.
+- **Zpracování:** latexový digitální tisk s možností detailního zpracování jakéhokoliv designu a barevné kombinace. Tisky laminujeme lesklou nebo matnou laminovací fólií, která zvyšuje odolnost zejména venku. Za stálobarevnost tisků ručíme **minimálně po dobu tří let**.
+
+**Blok `section_layout253`** (patří AŽ ZA první produktovou sekci)
+
+> **Klademe důraz na kvalitu a životnost**
+>
+> Moderní velkoformátový tisk realizujeme na vlastní tiskárně s latexovou technologií a ochrannou laminací, díky čemuž dosahujeme sytých barev a dlouhodobé odolnosti i v exteriéru.
+>
+> **Moderní technologie** — Vlastníme moderní tiskárnu určenou pro digitální tisk velkoplošných reklam a bannerů. Používáme technologii latexového tisku, která umožňuje dosáhnout plných, **sytých a dlouhodobě stálých barev**, a to i u detailních grafických návrhů a náročných barevných kombinací.
+>
+> **Maximální trvanlivost** — Tisky laminujeme, čímž se postaráme o maximální trvanlivost barev, a to hlavně u tisků venku, vystavených neustálému slunečnímu záření. Laminace chrání reklamu rovněž před mechanickým poškozením a na výběr je mezi **lesklou či matnou laminovací fólií**.
+
+### 2. Řezaná grafika — `#rezana-grafika`
+
+Štítky: Interiér i exteriér · Na míru
+
+Řezanou grafikou rozumíme nápisy vyřezané ze samolepicí fólie. Výhodou řezané grafiky je její dlouhá životnost. Je vhodná na všechny typy reklamních a informačních nápisů.
+
+- **Materiály:** samolepicí barevné fólie vhodné pro aplikaci na širokou škálu povrchů. Používané fólie mají stálobarevnost až sedm let.
+- **Zpracování:** nápis je plotrem vyřezán do požadovaného tvaru a následně aplikován na podkladovou plochu – tou může být téměř jakýkoliv povrch s dostatečnou přilnavostí. Neumožňují zhotovení například barevných přechodů a složitějších motivů v takové kvalitě jako digitální tisk. V případě potřeby proto tyto dvě techniky kombinujeme.
+
+### 3. Polepy — `#dalsi-druhy-polepu`
+
+Štítky: Interiér i exteriér · Na míru
+
+- **Polepy vozidel:** celkové i částečné, stejně jako samostatné nápisy. Návrh grafiky připravíme s vámi a zajistíme profesionální aplikaci.
+- **Polepy výloh a oken:** tištěnou nebo řezanou grafikou. Vhodné pro reklamní sdělení, informační texty, otevírací dobu, fotografie, loga.
+- **Perforované polepy oken:** omezují vhled do interiéru. Zároveň se zachovává výhled ven a nedochází k velikému omezení světla dovnitř.
+- **Krycí polepy oken:** zabraňují pohledu zvenku dovnitř. Nejčastěji používáme pískovanou fólii, která propouští světlo, ale omezuje průhled. Do fólie v různých odstínech lze vyřezávat motivy.
+- **Polepy podlah:** efektivně využívají prostor pro reklamu. Samolepicí protiskluzové fólie se hodí do provozoven i veřejných prostor.
+- **Bezpečnostní prvky pro šeroslepé:** pomáhají s bezpečným pohybem slabozrakým.
+
+### 4. Designové obrazy — `#designove-obrazy` *
+
+Štítky: Interiér · Na míru
+
+Navrhujeme a vyrábíme velkoformátové obrazy a nástěnné grafiky pro restaurace, kavárny, retail i firemní prostory – od stylových ilustrací přes výrazné brandové motivy.
+
+- **Materiály a tisk:** tiskneme na plátno (canvas), fólie i pevné desky jako Dibond či PVC, dodáváme obrazy v hliníkových i dřevěných rámech nebo v bezrámovém provedení.
+- **Zpracování:** zajišťujeme grafický návrh, precizní velkoformátový tisk ve vysokém rozlišení i profesionální montáž – vše přizpůsobujeme konkrétnímu prostoru, světlu i identitě značky.
+- **Výsledek:** vizuální prvek, který posiluje atmosféru, podporuje značku a dělá z interiéru místo, které si zákazníci pamatují i fotí.
+
+---
+
+## Vstupní portály a architektonické prvky
+
+**Hero H1:** Vstupní portály a architektonické prvky
+**Štítky hero:** 37 let zkušeností · Na míru · Neomezená kreativita
+
+**Karty rozcestníku**
+
+| Karta | Text |
+|---|---|
+| Vstupní portály | Vstupní portály představují efektivní způsob, jak upoutat pozornost zákazníka přímo v místě prodeje. |
+| Architektonické světelné prvky | V Elektru Drapač milujeme výzvy a rádi se podílíme na vymýšlení a realizaci unikátních architektonických projektů. |
+| Reklamní vlajky | Hodí se na místa, kde není dostatek prostoru pro jiný typ reklamy. |
+
+### 1. Vstupní portály — `#vstupni-portaly`
+
+Štítky: Interiér i exteriér · Na míru
+
+Jedná se o rámy kolem vstupních dveří ve světelném či nesvětelném provedení, které se liší svým designem. Součástí portálů mohou být loga, nápisy nebo sdělení.
+
+- **Materiály:** portály tvoří hliníková konstrukce, ve které mohou být umístěny LED diody. Podle požadavků na světelnost je opláštěna buď akrylátem, nebo sendvičovým materiálem, který je nesvětelný.
+- **Zpracování:** na portál lze umístit 3D nápis nebo jej zhotovit jako intarzii. Portál může být světelný, nesvětelný i s plastickým nápisem. Náš tým vytvoří individuální návrh s ohledem na možnosti budovy.
+- **Umístění:** u vchodů do prodejen či firem, aby jasně označily místo vstupu, upoutaly pozornost a sdělily návštěvníkům potřebné informace.
+
+### 2. Architektonické světelné prvky — `#architektonicke-prvky`
+
+Štítky: Interiér i exteriér · Na míru
+
+Jsme specialisté na světelné linky na fasádě budov, osvětlení fasád, dynamickou reklamu a fasádní pásy. Naší prioritou je najít to nejlepší technické a vizuální řešení.
+
+- **Materiály:** používáme kvalitní LED moduly s vysokou IP ochranou – jsou odolné vůči povětrnostním vlivům a zajišťují dlouhou životnost.
+- **Zpracování:** vedle designu řešíme také technické detaily, správné uchycení a přizpůsobení konkrétnímu prostoru, materiálu i okolním podmínkám provozu. Výsledkem je čisté řešení s vysokou funkčností a dlouhou životností.
+
+### 3. Reklamní vlajky — `#vlajky`
+
+Štítky: Interiér i exteriér · Na míru
+
+Vyrábíme reklamní textilní vlajky včetně vlajkových stožárů, které jsou ideální pro umístění tam, kde není prostor pro jiné typy reklamy, jako jsou billboardy nebo poutače.
+
+- **Zpracování:** tvar vlajky si můžete zvolit podle typu umístění – nabízíme tradiční obdélníkové, ale i speciální tvary. Vlajky jsou vyráběny z kvalitních materiálů, které zajišťují jejich dlouhou životnost.
+- **Umístění:** vhodné jsou zejména na místech s velkým pohybem lidí, jako jsou městské ulice, nákupní centra, festivaly nebo veletrhy. Díky pohybu ve větru mohou vlajky přitahovat ještě větší pozornost, což zvyšuje jejich účinnost.
+
+---
+
+## Prvky podpory prodeje, LED technologie
+
+**Hero H1:** Prvky podpory prodeje, LED technologie
+**Štítky hero:** 37 let zkušeností · Na míru · Neomezená kreativita
+
+**Karty rozcestníku**
+
+| Karta | Text |
+|---|---|
+| Prvky podpory prodeje | Propagační a reklamní prvky POP/POS na míru – stojany, displeje, totemy, držáky letáků i výlohové polepy ve široké škále barev. |
+| LED displaye | LED displeje slouží k zobrazení času, data, teploty, ceny (u čerpacích stanic) nebo k jinému informačnímu účelu. |
+| LED obrazovky | Nejmodernějšího řešení v rámci outdoorové i indoorové reklamy. Nabízíme i variabilní LED obrazovkové stěny či moduly. |
+
+### 1. Prvky podpory prodeje — `#prvky-podpory-prodeje`
+
+Štítky: Interiér i exteriér · Na míru
+
+Propagační a reklamní prvky se umisťují do obchodních prostor. Mají upoutat zákazníkovu pozornost, a tím zvýšit jeho zájem o koupi. Označují se zkratkami POP (point of purchase) a POS (point of sale).
+
+- **Umíme zhotovit:** stojany, displeje, poutače, reklamní totemy, regálové dekorace, držáky letáků, pokladní stojánky, nástěnné rámy, dekorace nákupních vozíků, výlohové polepy, tašky a držáky nápojů, samolepky a další.
+- **Zpracování:** existuje velké množství barevného provedení a široká škála použitelných materiálů. Stačí se jen domluvit a my vám vyrobíme reklamní prvky podporující váš prodej na míru.
+
+### 2. LED displaye — `#led-displaye`
+
+Štítky: Interiér i exteriér · Na míru
+
+LED displaye zobrazují například čas, datum, teplotu či cenu (u čerpacích stanic). Ovládají se dálkovým ovladačem, aplikací nebo přes datovou síť. Jsou i součástí reklamních totemů. Vybírat můžete z mnoha barev a dvou typů displejů:
+
+- **Segmentové displeje:** segmentové LED displeje umějí zobrazit číslice od 0 do 9 a textové znaky. Podle počtu segmentů se dělí na čtyři typy: 7 a 9segmentové (zobrazují číslice a některé textové znaky), 14 a 16segmentové (zobrazují číslice a textové znaky latinky).
+- **Maticové displeje:** maticové displeje jsou tvořeny polem LED diod seskupených povětšinou do čtvercové matice. Na čtvercové matici 8 × 8 LED lze kromě čísel a textu zobrazovat i jednoduchou grafiku.
+
+### 3. LED obrazovky — `#led-obrazovky`
+
+Štítky: Interiér i exteriér · Na míru
+
+LED obrazovky můžou být velikosti plátna v kině, poutavé jako váš oblíbený film a aktuální jako denní tisk. Lze na nich prezentovat reklamní spoty i fotografie. Patří k nákladnějším formám reklamy, jejich efekt je však jedinečný.
+
+- **Technické parametry LED obrazovek:** stavební moduly mají standardně 16 × 8 nebo 16 × 16 pixelů. Na přání zákazníka lze sestavit LED obrazovku rozmanitých tvarů a v prakticky neomezené velikosti.
+- **Zpracování LED obrazovek:** moduly se zasazují do segmentů vyrobených z hliníku, který je opatřen povrchovou úpravou. Následně se instalují na připravenou konstrukci.
+
+> Návrh nemá u této sekce produktovou fotku (jen barevná plocha). Bere se
+> fotka ze živé stránky.
+
+---
+
+## Světelné panely a tabule
+
+**Hero H1:** Světelné panely a tabule
+**Podnadpis:** Světelné panely vyrábíme **na míru vašim potřebám** do velikosti 100 m² se špičkovým zpracováním a designem.
+**Štítky hero:** Životnost desítky let · Úsporné LED · Odborná montáž · Kompletní servis
+
+**Karty rozcestníku**
+
+| Karta | Text |
+|---|---|
+| Světelné panely | Moderní reklamní prvek, který zajišťuje vysokou viditelnost díky svítící čelní straně. |
+| Plexi intarzie | Světelné panely s vystouplými 3D světelnými znaky pro atraktivní prezentaci. |
+| Reklamní tabule | Efektivní, cenově dostupné reklamní prvky sloužící k označení / orientaci v prostoru. |
+| Menuboardy/infoboardy | Praktické a flexibilní reklamní panely, které umožňují snadnou výměnu grafiky. |
+
+### 1. Světelné panely — `#svetelne-panely`
+
+Štítky: Svítící čelní strana · Nenáročné na montáž
+
+Box s hliníkovým rámem, který na přední straně využívá prosvětlovací materiál. V nabídce je několik variant, včetně plachtového a plexisklového panelu a varianty s 3D písmem.
+
+- **Grafika:** na prosvětlovací plochu lze aplikovat tištěnou nebo řezanou grafiku. Tyto grafické možnosti umožňují přizpůsobení vzhledu panelu podle potřeby a specifických požadavků.
+- **Materiál:** hliníkový rám a zadní strana z hliníku nebo sendvičové desky. Přední plocha z plexiskla nebo prosvětlovací vinylové plachty, která zajišťuje dlouhou životnost a kvalitní prosvětlení.
+- **Umístění:** světelné panely se dají snadno namontovat na budovy či pylony.
+
+### 2. Plexi intarzie — `#intarzie`
+
+Štítky: Atraktivní vzhled · Světelná aura
+
+Intarzie je světelný panel s vystouplými nebo vnořenými znaky.
+
+- **Grafika:** jedná se o vhodnější provedení u malých nápisů s velice tenkým fontem písma, kdy by nebylo možné tvarovat jako samostatný 3D nápis.
+- **Materiál:** kostru tvoří rám a zadní strana z hliníku. Přední plocha je pokryta neprůsvitnou deskou (většinou vyrobenou z plechu nebo sendvičové desky – dibondu).
+- **Umístění:** výhodou např. u historických budov, kde není možnost vrtat do fasády – elektropřívod je veden pouze do jednoho místa.
+
+Dva podbloky návrhu (jdou nad rámec šablony, řeší se odrážkami):
+
+- **Vystouplá plexiintarzie:** znaky **nad úrovní** panelu (vytvářejí 3D efekt); do čelní strany jsou prořezány otvory, do nichž jsou vsazeny světelné znaky z masivního plexiskla; díky prosvětleným bokům písmen vzniká světelná aura.
+- **Podložená plexiintarzie:** znaky **pod úrovní** panelu; jedná se o ekonomičtější variantu, neboť se znaky nemusejí tvarovat a výroba je méně pracná; nevzniká světelná aura.
+
+### 3. Reklamní tabule — `#reklamni-tabule`
+
+Štítky: Nízká pořizovací cena · Rychlé dodání
+
+Reklamní tabule, neboli nesvětelná reklamní deska, je jedním z nejjednodušších řešení reklamního prvku. Lze počítat s flexibilitou – grafiku na tabuli lze znovu přelepit.
+
+- **Grafika:** sdělení na jejich povrchu může být zrealizováno tištěnou či řezanou grafikou, pískováním a gravírováním.
+- **Materiál:** jedná se o nesvětelné desky vyráběné z různých materiálů, jako je hliník, nerez, mosaz, kompozitní materiály, akryláty, sklo, dřevo apod.
+- **Umístění:** označení provozoven, informační nebo orientační účely. Nejčastěji jako nesvětelné nápisy, informační tabule, dveřní tabulky, orientační systémy apod.
+
+### 4. Menuboardy/infoboardy — `#menuboardy`
+
+Štítky: Snadná výměna · Dlouhá životnost
+
+Menuboardy jsou speciální panely s vyměnitelnými motivy. Mohou být oboustranné pro snadnou výměnu.
+
+- **Grafika:** umožňují zobrazení aktuálních nabídek pomocí vyměnitelných motivů. Grafiku lze snadno měnit a přizpůsobovat.
+- **Materiál:** odolné materiály, které zajišťují dlouhou životnost. Materiály jsou přizpůsobeny pro výměnu grafiky a používání v restauracích.
+- **Umístění:** používají se především v restauracích s rychlým občerstvením, kde zobrazují aktuální nabídku pokrmů a nápojů.
+
+---
+
+## Designová a interiérová svítidla
+
+**Hero H1:** Neonová a LED neonová designová svítidla
+**Štítky hero:** 37 let zkušeností · Na míru · Neomezená kreativita
+
+Sedm sekcí: `designova-svitidla`, `zarovkove-svetelne-napisy`,
+`neonove-napisy`, `mechove-steny`, `reklama-z-cortenoveho-plechu`,
+`svetelna-cisla-domu`, `stojaci-lampy`.
+
+### 1. Designová svítidla — `#designova-svitidla`
+
+Štítky: Interiér · Na míru
+
+Hledáte pro svůj prostor něco unikátního? Netradiční designové osvětlení může zcela změnit atmosféru interiéru, dodat mu charakter a zároveň splnit funkční požadavky.
+
+- **Výroba na míru:** ať už jde o moderní minimalistické prvky, nebo o luxusní, kreativní řešení, jsme schopni přizpůsobit každý detail tak, aby odpovídal vašim představám a potřebám.
+- **Umístění:** designová svítidla mohou mít různé tvary a velikosti, a to jak pro komerční prostory, tak i pro rezidenční interiéry, ať už jde o restaurace, kanceláře anebo hotely.
+
+*(sekce 2–7 se doplňují při stavbě stránky — návrh je u nich ve
+screenshotu v nízkém rozlišení a přepisuje se po částech)*

--- a/docs/produktove-stranky-texty.md
+++ b/docs/produktove-stranky-texty.md
@@ -310,5 +310,70 @@ Hledáte pro svůj prostor něco unikátního? Netradiční designové osvětlen
 - **Výroba na míru:** ať už jde o moderní minimalistické prvky, nebo o luxusní, kreativní řešení, jsme schopni přizpůsobit každý detail tak, aby odpovídal vašim představám a potřebám.
 - **Umístění:** designová svítidla mohou mít různé tvary a velikosti, a to jak pro komerční prostory, tak i pro rezidenční interiéry, ať už jde o restaurace, kanceláře anebo hotely.
 
-*(sekce 2–7 se doplňují při stavbě stránky — návrh je u nich ve
-screenshotu v nízkém rozlišení a přepisuje se po částech)*
+### 2. Žárovkové světelné nápisy — `#zarovkove-svetelne-napisy`
+
+Štítky: Interiér a exteriér · Na míru
+
+Hledáte pro svůj prostor něco unikátního? Netradiční designové osvětlení může zcela změnit atmosféru prostoru, dodat mu charakter a zároveň splnit funkční požadavky.
+
+- **Zpracování:** žárovkový světelný nápis tvoří plechový korpus, v němž jsou umístěny žárovičky. Dbáme na kvalitu i ekologičnost a používáme vysoce úsporné LED žárovky s možností volby odstínu světla.
+- **Umístění:** vhodné jsou zejména pro komerční prostory, restaurace, obchody, kina nebo klubové prostory, kde přitahují pozornost zákazníků a dodávají místu jedinečný charakter. Můžete je umístit nad vchod, na fasádu budovy, nebo použít jako interiérovou dekoraci.
+
+### 3. Neonové nápisy & imitace — `#neonove-napisy`
+
+Štítky: Interiér a exteriér · Na míru
+
+Klasické skleněné neonové trubice dodávají reklamě nezaměnitelný charakter, jedinečnou kresbu světla a autentický vizuální efekt.
+
+- **Neonové trubice** umožňují vytvořit originální nápisy, loga i designové prvky s atmosférou, kterou jiné technologie jen těžko napodobí.
+- **Imitace neonového nápisu z plexiskla:** plexisklo ohýbáme do zvoleného tvaru a prosvítíme pomocí kvalitních LED modulů. Výsledkem je luxusní efekt s vysokou úsporou oproti klasickým neonům – a díky absenci skla i bezpečnější volba do interiéru.
+- **Umístění:** jsou ideální tam, kde je cílem originalita, styl a skutečný neonový dojem. Výsledkem je světelný prvek, který zaujme svou estetikou i řemeslným zpracováním.
+
+**Blok `section_layout253`** (patří za sekci Neonové nápisy)
+
+> **Neonové nápisy: Klasika s moderním twistem**
+>
+> Neonové nápisy se řadí mezi nesmrtelnou klasiku, která se nesmazatelně zapsala do historie světelné reklamy.
+>
+> **Jak fungují tradiční neonové nápisy?** — Klasické neonové nápisy se skládají ze žárem tvarovaných skleněných trubic, které po naplnění plynem září červeně. Různé barevnosti světla lze docílit naplněním trubice luminoforovým práškem a argonem. Na každé trubici je navařena elektroda propojená s vysokonapěťovým transformátorem, která je izolována silikonovým návlekem.
+>
+> **Proč raději doporučujeme imitaci neonových nápisů?** — Kvůli luxusnímu vzhledu za dostupnou cenu. Tradiční neonové nápisy jsou sice krásné, ale mají své nevýhody, jako je vyšší pořizovací cena, náročnost na údržbu a vysoká spotřeba energie. Moderní imitace neonových nápisů však nabízejí stejný vizuální efekt, ale za podstatně nižší cenu.
+
+### 4. Mechové stěny — `#mechove-steny`
+
+Štítky: Interiér · Na míru
+
+Ve spolupráci s našimi dodavateli jsme schopni pro vás zhotovit nejen mechové stěny, ale také mechové obrazy s reklamním nápisem.
+
+- **Proč mechové stěny:** vypadají skvěle a mají praktické výhody. Jsou ekologické, snadno se udržují a nevyžadují žádnou údržbu jako živé rostliny. Navíc pomáhají zlepšit akustiku místnosti a čistit vzduch.
+- **Umístění:** jsou ideální pro kancelářské prostory, firemní lobby a recepce, restaurace a hotely, obchodní prostory nebo showroomy, kde se dají skvěle kombinovat s reklamními nápisy a logy.
+
+### 5. Reklama z cortenového plechu — `#reklama-z-cortenoveho-plechu`
+
+Štítky: Exteriér a interiér · Na míru
+
+Materiál s přirozenou rezavou patinou, která časem získává jedinečný vzhled a je ideální pro fasády nebo do venkovních prostor.
+
+- **Materiál:** patinující ocel (známá jako rezavá ocel) je velmi odolná a ideální pro umístění především do exteriéru. Vyznačuje se charakteristickým vzhledem díky své přirozeně rezavé patině, která se časem vyvíjí, což přidává jedinečný estetický efekt.
+- **Umístění:** cortenová ocel se používá nejen pro reklamní nápisy, ale i pro různé designové prvky, jako jsou loga, grafické vzory a dekorativní panely, které lze umístit na fasády budov nebo do venkovních prostor.
+
+### 6. Světelná čísla domů — `#svetelna-cisla-domu`
+
+Štítky: Exteriér · Na míru
+
+Přidejte svému obydlí výjimečnosti a zkrášlete jeho exteriér pomocí světelného či nesvětelného čísla. Světelná čísla jsou nejen praktickým řešením, ale i designovým prvkem.
+
+- **Provedení:** můžete si vybrat z různých typů podsvícení, které zajistí viditelnost i v noci, či varianty bez podsvícení, které mohou být elegantním a moderním doplňkem. Zda zvolíte teple bílé světlo, nebo studeně modré podsvícení, vše přizpůsobíme vašim přáním.
+- **Instalace:** zajistíme vám kompletní výrobu a instalaci čísel, která se hodí k jakémukoliv stylu a typu budovy.
+
+### 7. Designové stojací lampy na zakázku — `#stojaci-lampy`
+
+Štítky: Interiér · Na míru
+
+Nechte si lampu vyrobit na zakázku, nebo si vyberte z připravených návrhů či z nabídky hotových svítidel. Náš tým techniků se nezalekne žádné výzvy a zhmotní vaši vizi.
+
+- **Využití:** stojací lampy nemusejí sloužit pouze jako interiérový doplněk. Lze je využít i v komerčních prostorách například jako stojan na produkty či upozornění a směrovky.
+- **Svícení:** v celém barevném spektru, bezdrátové svícení a další inovativní prvky jsou u našich projektů samozřejmostí. Možnost ovládání dálkovým ovladačem, prostřednictvím aplikace Hue, Apple Home, DALI a dalších systémů.
+
+**Karty rozcestníku** — text karet je ve screenshotu nečitelný, proto se
+odvozuje z úvodní věty každé sekce (zapsáno jako rozhodnutí za pochodu).


### PR DESCRIPTION
Podklad pro přestavbu osmi produktových stránek podle Figma návrhu. Zatím jen dokumentace — samotná práce probíhá ve Webflow, do repozitáře se promítne jen tehdy, když bude potřeba custom kód.

## Co přibylo

`docs/produktove-stranky-figma.md` — spáruje framy ve Figma souboru s produktovými stránkami ve Webflow a popisuje kostru produktové stránky.

Framy v návrhu nejsou pojmenované, párování vzniklo z názvů vrstev a ověřilo se screenshotem hero sekcí. Kotvy sekcí se berou z menu na živém webu, protože návrh je u dvou stránek nemá.

## Co se při zjišťování našlo

- **Rozcestník „Podívejte se blíže na to, co vás zajímá" nese třídu `section_layout400`**, ne `section_cards`. `section_cards` je starší skrytý duplikát téhož obsahu a na nové stránky nepatří.
- **Pylony mají dvě sekce se stejným DOM id `totemy`** — nevalidní HTML, kotva skočí jen na první.
- **Sekci „Jak probíhá výroba" nese duplikát třídy** `section_layout121 2`; na 3D nápisech je zabalená v komponentě, na pylonech je to lokální kopie.
- **Návrh má u dvou stránek víc sekcí než menu** — Výstrčím přibyly *Atypické výstrče*, velkoformátovému tisku *Designové obrazy*.
- **Produktové stránky mají vyplněné EN a DE překlady.** Stránka vzniklá duplikací je má prázdné, takže postup s výměnou stránky o ně přijde.

## Ověřování

Nic z toho není odhad z Designeru — struktura i kotvy jsou odečtené ze živého HTML obou hotových stránek, existence překladů z `/en/` verze.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QwBc9aP25bzN4TazddV548

---
_Generated by [Claude Code](https://claude.ai/code/session_01QwBc9aP25bzN4TazddV548)_